### PR TITLE
JAVAFIXTURE-6 Add Specimen for Temporal interface and java.time.package

### DIFF
--- a/src/main/java/com/github/nylle/javafixture/ReflectionHelper.java
+++ b/src/main/java/com/github/nylle/javafixture/ReflectionHelper.java
@@ -1,14 +1,17 @@
 package com.github.nylle.javafixture;
 
+import static java.lang.String.format;
+
 import java.lang.reflect.Array;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.time.ZoneId;
+import java.time.temporal.TemporalAdjuster;
+import java.time.temporal.TemporalAmount;
 import java.util.Collection;
 import java.util.Map;
-
-import static java.lang.String.format;
 
 
 public class ReflectionHelper {
@@ -81,6 +84,19 @@ public class ReflectionHelper {
         } catch (IllegalAccessException e) {
             return true;
         }
+    }
+
+    public static boolean isTimeType( Class<?> type ) {
+        if ( TemporalAdjuster.class.isAssignableFrom( type ) ) {
+            return true;
+        }
+        if ( TemporalAmount.class.isAssignableFrom( type ) ) {
+            return true;
+        }
+        if( type.equals( ZoneId.class )) {
+            return true;
+        }
+        return false;
     }
 
     private static <T> T getDefaultValueForPrimitiveOrNull(Class<T> type) {

--- a/src/main/java/com/github/nylle/javafixture/SpecimenFactory.java
+++ b/src/main/java/com/github/nylle/javafixture/SpecimenFactory.java
@@ -1,14 +1,22 @@
 package com.github.nylle.javafixture;
 
+import java.lang.reflect.Type;
+import java.time.Duration;
+import java.time.MonthDay;
+import java.time.Period;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.temporal.Temporal;
+
 import com.github.nylle.javafixture.specimen.ArraySpecimen;
 import com.github.nylle.javafixture.specimen.CollectionSpecimen;
 import com.github.nylle.javafixture.specimen.EnumSpecimen;
+import com.github.nylle.javafixture.specimen.InterfaceSpecimen;
 import com.github.nylle.javafixture.specimen.MapSpecimen;
 import com.github.nylle.javafixture.specimen.ObjectSpecimen;
 import com.github.nylle.javafixture.specimen.PrimitiveSpecimen;
-import com.github.nylle.javafixture.specimen.InterfaceSpecimen;
-
-import java.lang.reflect.Type;
+import com.github.nylle.javafixture.specimen.TemporalSpecimen;
+import com.github.nylle.javafixture.specimen.TimeSpecimen;
 
 public class SpecimenFactory {
 
@@ -43,8 +51,36 @@ public class SpecimenFactory {
         if(type.isInterface()) {
             return new InterfaceSpecimen<>(type, context, this);
         }
+        if(isTimeSpecimen(type)) {
+            return new TimeSpecimen<>( type );
+        }
+        if(Temporal.class.isAssignableFrom(type)) {
+            return new TemporalSpecimen<>( type, context );
+        }
 
         return new ObjectSpecimen<>(type, context, this);
+    }
+
+    private static boolean isTimeSpecimen( Class type ) {
+        if(type.equals(Duration.class)) {
+            return true;
+        }
+        if(type.equals(Period.class)) {
+            return true;
+        }
+
+        if(type.equals(MonthDay.class)) {
+            return true;
+        }
+
+        if(type.equals(ZoneId.class)) {
+            return true;
+        }
+
+        if(type.equals(ZoneOffset.class)) {
+            return true;
+        }
+        return false;
     }
 
     public <T> ISpecimen<T> build(final Class<T> type, final Type genericType) {

--- a/src/main/java/com/github/nylle/javafixture/SpecimenFactory.java
+++ b/src/main/java/com/github/nylle/javafixture/SpecimenFactory.java
@@ -51,11 +51,11 @@ public class SpecimenFactory {
         if(type.isInterface()) {
             return new InterfaceSpecimen<>(type, context, this);
         }
-        if(isTimeSpecimen(type)) {
-            return new TimeSpecimen<>( type );
-        }
         if(Temporal.class.isAssignableFrom(type)) {
             return new TemporalSpecimen<>( type, context );
+        }
+        if(ReflectionHelper.isTimeType( type)) {
+            return new TimeSpecimen<>( type );
         }
 
         return new ObjectSpecimen<>(type, context, this);

--- a/src/main/java/com/github/nylle/javafixture/specimen/TemporalSpecimen.java
+++ b/src/main/java/com/github/nylle/javafixture/specimen/TemporalSpecimen.java
@@ -1,0 +1,44 @@
+package com.github.nylle.javafixture.specimen;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.time.temporal.Temporal;
+
+import com.github.nylle.javafixture.Context;
+import com.github.nylle.javafixture.ISpecimen;
+import com.github.nylle.javafixture.SpecimenException;
+
+
+public class TemporalSpecimen<T> implements ISpecimen<T> {
+
+    private final Class<T> type;
+    private final Context context;
+
+    public TemporalSpecimen( Class<T> type, Context context ) {
+        if ( type == null ) {
+            throw new IllegalArgumentException( "type: null" );
+        }
+
+        if ( !Temporal.class.isAssignableFrom( type ) ) {
+            throw new IllegalArgumentException( "type: " + type.getName() );
+        }
+
+        if ( context == null ) {
+            throw new IllegalArgumentException( "context: null" );
+        }
+
+        this.type = type;
+        this.context = context;
+    }
+
+    @Override
+    public T create() {
+        try {
+            Method now = type.getMethod( "now" );
+            return (T) now.invoke( null );
+        } catch ( NoSuchMethodException | IllegalAccessException | InvocationTargetException e ) {
+            throw new SpecimenException( "Unsupported type: " + type );
+        }
+
+    }
+}

--- a/src/main/java/com/github/nylle/javafixture/specimen/TimeSpecimen.java
+++ b/src/main/java/com/github/nylle/javafixture/specimen/TimeSpecimen.java
@@ -1,0 +1,72 @@
+package com.github.nylle.javafixture.specimen;
+
+import java.time.Duration;
+import java.time.MonthDay;
+import java.time.Period;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.temporal.TemporalAmount;
+import java.util.Random;
+
+import com.github.nylle.javafixture.ISpecimen;
+import com.github.nylle.javafixture.SpecimenException;
+
+public class TimeSpecimen<T> implements ISpecimen<T> {
+
+    private final Class<T> type;
+    private final Random random;
+
+    public TimeSpecimen( Class<T> type ) {
+        if ( type == null ) {
+            throw new IllegalArgumentException( "type: null" );
+        }
+
+        if ( !isTimeClass( type ) ) {
+            throw new IllegalArgumentException( "type: " + type.getName() );
+        }
+
+        this.type = type;
+        this.random = new Random();
+    }
+
+    private static boolean isTimeClass( Class type ) {
+        if ( TemporalAmount.class.isAssignableFrom( type ) ) {
+            return true;
+        }
+        if ( type.equals( MonthDay.class ) ) {
+            return true;
+        }
+        if ( type.equals( ZoneId.class ) ) {
+            return true;
+        }
+        if ( type.equals( ZoneOffset.class ) ) {
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public T create() {
+        if ( type.equals( Duration.class ) ) {
+            return (T) Duration.ofDays( random.nextInt() );
+        }
+
+        if ( type.equals( Period.class ) ) {
+            return (T) Period.ofDays( random.nextInt() );
+        }
+
+        if ( type.equals( MonthDay.class ) ) {
+            return (T) MonthDay.now();
+        }
+
+        if ( type.equals( ZoneId.class ) ) {
+            return (T) ZoneId.of( ZoneId.getAvailableZoneIds().iterator().next() );
+        }
+
+        if ( type.equals( ZoneOffset.class ) ) {
+            return (T) ZoneOffset.ofHours( new Random().nextInt( 19 ) );
+        }
+
+        throw new SpecimenException( "Unsupported type: " + type );
+    }
+}

--- a/src/main/java/com/github/nylle/javafixture/specimen/TimeSpecimen.java
+++ b/src/main/java/com/github/nylle/javafixture/specimen/TimeSpecimen.java
@@ -5,10 +5,11 @@ import java.time.MonthDay;
 import java.time.Period;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
-import java.time.temporal.TemporalAmount;
+import java.time.chrono.JapaneseEra;
 import java.util.Random;
 
 import com.github.nylle.javafixture.ISpecimen;
+import com.github.nylle.javafixture.ReflectionHelper;
 import com.github.nylle.javafixture.SpecimenException;
 
 public class TimeSpecimen<T> implements ISpecimen<T> {
@@ -21,7 +22,7 @@ public class TimeSpecimen<T> implements ISpecimen<T> {
             throw new IllegalArgumentException( "type: null" );
         }
 
-        if ( !isTimeClass( type ) ) {
+        if ( !ReflectionHelper.isTimeType( type ) ) {
             throw new IllegalArgumentException( "type: " + type.getName() );
         }
 
@@ -29,24 +30,19 @@ public class TimeSpecimen<T> implements ISpecimen<T> {
         this.random = new Random();
     }
 
-    private static boolean isTimeClass( Class type ) {
-        if ( TemporalAmount.class.isAssignableFrom( type ) ) {
-            return true;
-        }
-        if ( type.equals( MonthDay.class ) ) {
-            return true;
-        }
-        if ( type.equals( ZoneId.class ) ) {
-            return true;
-        }
-        if ( type.equals( ZoneOffset.class ) ) {
-            return true;
-        }
-        return false;
-    }
-
     @Override
     public T create() {
+        if ( type.equals( MonthDay.class ) ) {
+            return (T) MonthDay.now();
+        }
+
+        if ( type.equals( JapaneseEra.class ) ) {
+            return (T) JapaneseEra.values()[random.nextInt( JapaneseEra.values().length )];
+        }
+
+        if ( type.equals( ZoneOffset.class ) ) {
+            return (T) ZoneOffset.ofHours( new Random().nextInt( 19 ) );
+        }
         if ( type.equals( Duration.class ) ) {
             return (T) Duration.ofDays( random.nextInt() );
         }
@@ -55,16 +51,8 @@ public class TimeSpecimen<T> implements ISpecimen<T> {
             return (T) Period.ofDays( random.nextInt() );
         }
 
-        if ( type.equals( MonthDay.class ) ) {
-            return (T) MonthDay.now();
-        }
-
         if ( type.equals( ZoneId.class ) ) {
             return (T) ZoneId.of( ZoneId.getAvailableZoneIds().iterator().next() );
-        }
-
-        if ( type.equals( ZoneOffset.class ) ) {
-            return (T) ZoneOffset.ofHours( new Random().nextInt( 19 ) );
         }
 
         throw new SpecimenException( "Unsupported type: " + type );

--- a/src/test/java/com/github/nylle/javafixture/ReflectionHelperTest.java
+++ b/src/test/java/com/github/nylle/javafixture/ReflectionHelperTest.java
@@ -1,10 +1,13 @@
 package com.github.nylle.javafixture;
 
-import com.github.nylle.javafixture.testobjects.TestObject;
-import com.github.nylle.javafixture.testobjects.TestPrimitive;
-import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import java.lang.reflect.Type;
+import java.time.Duration;
+import java.time.MonthDay;
+import java.time.Period;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.chrono.JapaneseEra;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Deque;
@@ -32,7 +35,12 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.LinkedTransferQueue;
 import java.util.concurrent.TransferQueue;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.Test;
+
+import com.github.nylle.javafixture.parameterized.TestCase;
+import com.github.nylle.javafixture.parameterized.TestWithCases;
+import com.github.nylle.javafixture.testobjects.TestObject;
+import com.github.nylle.javafixture.testobjects.TestPrimitive;
 
 class ReflectionHelperTest {
 
@@ -137,5 +145,17 @@ class ReflectionHelperTest {
 
         assertThat(ReflectionHelper.isStatic(staticField)).isTrue();
         assertThat(ReflectionHelper.isStatic(field)).isFalse();
+    }
+
+    @TestWithCases
+    @TestCase(class1 = Duration.class, bool2 = true)
+    @TestCase(class1 = JapaneseEra.class, bool2 = true)
+    @TestCase(class1 = MonthDay.class, bool2 = true)
+    @TestCase(class1 = Period.class, bool2 = true)
+    @TestCase(class1 = String.class, bool2 = false)
+    @TestCase(class1 = ZoneId.class, bool2 = true)
+    @TestCase(class1 = ZoneOffset.class, bool2 = true )
+    void isTimeClass(Class type, boolean expected) {
+        assertThat( ReflectionHelper.isTimeType( type ) ).isEqualTo( expected );
     }
 }

--- a/src/test/java/com/github/nylle/javafixture/SpecimenFactoryTest.java
+++ b/src/test/java/com/github/nylle/javafixture/SpecimenFactoryTest.java
@@ -1,5 +1,20 @@
 package com.github.nylle.javafixture;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.lang.reflect.Type;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.MonthDay;
+import java.time.Period;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
 import com.github.nylle.javafixture.specimen.ArraySpecimen;
 import com.github.nylle.javafixture.specimen.CollectionSpecimen;
 import com.github.nylle.javafixture.specimen.EnumSpecimen;
@@ -7,16 +22,10 @@ import com.github.nylle.javafixture.specimen.InterfaceSpecimen;
 import com.github.nylle.javafixture.specimen.MapSpecimen;
 import com.github.nylle.javafixture.specimen.ObjectSpecimen;
 import com.github.nylle.javafixture.specimen.PrimitiveSpecimen;
+import com.github.nylle.javafixture.specimen.TemporalSpecimen;
+import com.github.nylle.javafixture.specimen.TimeSpecimen;
 import com.github.nylle.javafixture.testobjects.TestObject;
 import com.github.nylle.javafixture.testobjects.complex.IContract;
-import org.junit.jupiter.api.Test;
-
-import java.lang.reflect.Type;
-import java.util.List;
-import java.util.Map;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class SpecimenFactoryTest {
 
@@ -33,6 +42,12 @@ class SpecimenFactoryTest {
         assertThat(sut.build(List.class)).isExactlyInstanceOf(CollectionSpecimen.class);
         assertThat(sut.build(int[].class)).isExactlyInstanceOf(ArraySpecimen.class);
         assertThat(sut.build(IContract.class)).isExactlyInstanceOf(InterfaceSpecimen.class);
+        assertThat(sut.build(Duration.class)).isExactlyInstanceOf(TimeSpecimen.class);
+        assertThat(sut.build(Period.class)).isExactlyInstanceOf(TimeSpecimen.class);
+        assertThat(sut.build(MonthDay.class)).isExactlyInstanceOf(TimeSpecimen.class);
+        assertThat(sut.build(ZoneId.class)).isExactlyInstanceOf(TimeSpecimen.class);
+        assertThat(sut.build(ZoneOffset.class)).isExactlyInstanceOf(TimeSpecimen.class);
+        assertThat(sut.build(Instant.class)).isExactlyInstanceOf(TemporalSpecimen.class);
         assertThat(sut.build(Object.class)).isExactlyInstanceOf(ObjectSpecimen.class);
     }
 

--- a/src/test/java/com/github/nylle/javafixture/SpecimenFactoryTest.java
+++ b/src/test/java/com/github/nylle/javafixture/SpecimenFactoryTest.java
@@ -42,11 +42,11 @@ class SpecimenFactoryTest {
         assertThat(sut.build(List.class)).isExactlyInstanceOf(CollectionSpecimen.class);
         assertThat(sut.build(int[].class)).isExactlyInstanceOf(ArraySpecimen.class);
         assertThat(sut.build(IContract.class)).isExactlyInstanceOf(InterfaceSpecimen.class);
-        assertThat(sut.build(Duration.class)).isExactlyInstanceOf(TimeSpecimen.class);
-        assertThat(sut.build(Period.class)).isExactlyInstanceOf(TimeSpecimen.class);
-        assertThat(sut.build(MonthDay.class)).isExactlyInstanceOf(TimeSpecimen.class);
-        assertThat(sut.build(ZoneId.class)).isExactlyInstanceOf(TimeSpecimen.class);
-        assertThat(sut.build(ZoneOffset.class)).isExactlyInstanceOf(TimeSpecimen.class);
+        assertThat(sut.build(Duration.class)).isExactlyInstanceOf( TimeSpecimen.class);
+        assertThat(sut.build(Period.class)).isExactlyInstanceOf( TimeSpecimen.class);
+        assertThat(sut.build(MonthDay.class)).isExactlyInstanceOf( TimeSpecimen.class);
+        assertThat(sut.build(ZoneId.class)).isExactlyInstanceOf( TimeSpecimen.class);
+        assertThat(sut.build(ZoneOffset.class)).isExactlyInstanceOf( TimeSpecimen.class);
         assertThat(sut.build(Instant.class)).isExactlyInstanceOf(TemporalSpecimen.class);
         assertThat(sut.build(Object.class)).isExactlyInstanceOf(ObjectSpecimen.class);
     }

--- a/src/test/java/com/github/nylle/javafixture/specimen/TemporalSpecimenTest.java
+++ b/src/test/java/com/github/nylle/javafixture/specimen/TemporalSpecimenTest.java
@@ -1,0 +1,95 @@
+package com.github.nylle.javafixture.specimen;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.OffsetTime;
+import java.time.Year;
+import java.time.YearMonth;
+import java.time.ZonedDateTime;
+import java.time.chrono.HijrahDate;
+import java.time.chrono.JapaneseDate;
+import java.time.chrono.MinguoDate;
+import java.time.chrono.ThaiBuddhistDate;
+import java.time.temporal.Temporal;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import com.github.nylle.javafixture.Configuration;
+import com.github.nylle.javafixture.Context;
+import com.github.nylle.javafixture.SpecimenException;
+import com.github.nylle.javafixture.SpecimenFactory;
+import com.github.nylle.javafixture.parameterized.TestCase;
+import com.github.nylle.javafixture.parameterized.TestWithCases;
+
+class TemporalSpecimenTest {
+
+    private Context context;
+    private SpecimenFactory specimenFactory;
+
+    @BeforeEach
+    void setup() {
+        context = new Context( new Configuration( 2, 2, 3 ) );
+        specimenFactory = new SpecimenFactory( context );
+    }
+
+    @Test
+    void onlyTemporalTypes() {
+        assertThatThrownBy( () -> new TemporalSpecimen( Map.class, context ) )
+                .isInstanceOf( IllegalArgumentException.class )
+                .hasMessageContaining( "type: " + Map.class.getName() );
+    }
+
+    @Test
+    void typeIsRequired() {
+        assertThatThrownBy( () -> new TemporalSpecimen<>( null, context ) )
+                .isInstanceOf( IllegalArgumentException.class )
+                .hasMessageContaining( "type: null" );
+    }
+
+    @Test
+    void contextIsRequired() {
+        assertThatThrownBy( () -> new TemporalSpecimen<>( Instant.class, null ) )
+                .isInstanceOf( IllegalArgumentException.class )
+                .hasMessageContaining( "context: null" );
+    }
+
+    @Test
+    void throwsExceptionForUnknownType() {
+        assertThatThrownBy( () -> new TemporalSpecimen<>( Mockito.mock( Temporal.class ).getClass(), context ).create() )
+                .isInstanceOf( SpecimenException.class )
+                .hasMessageContaining( "Unsupported type:" );
+    }
+
+    @TestWithCases
+    @TestCase(class1 = Instant.class)
+    @TestCase(class1 = HijrahDate.class)
+    @TestCase(class1 = JapaneseDate.class)
+    @TestCase(class1 = LocalDate.class)
+    @TestCase(class1 = LocalDateTime.class)
+    @TestCase(class1 = LocalTime.class)
+    @TestCase(class1 = MinguoDate.class)
+    @TestCase(class1 = OffsetDateTime.class)
+    @TestCase(class1 = OffsetTime.class)
+    @TestCase(class1 = ThaiBuddhistDate.class)
+    @TestCase(class1 = Year.class)
+    @TestCase(class1 = YearMonth.class)
+    @TestCase(class1 = ZonedDateTime.class)
+    @DisplayName( "create should return a valid object" )
+    void create( Class type ) {
+        var sut = new TemporalSpecimen<>( type, context ).create();
+        // if the object is not valid, the toString method will fail, is cannot print it
+        assertThat( sut.toString()).isNotEmpty();
+    }
+
+}

--- a/src/test/java/com/github/nylle/javafixture/specimen/TimeSpecimenTest.java
+++ b/src/test/java/com/github/nylle/javafixture/specimen/TimeSpecimenTest.java
@@ -1,0 +1,58 @@
+package com.github.nylle.javafixture.specimen;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Duration;
+import java.time.MonthDay;
+import java.time.Period;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.temporal.TemporalAmount;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import com.github.nylle.javafixture.SpecimenException;
+import com.github.nylle.javafixture.parameterized.TestCase;
+import com.github.nylle.javafixture.parameterized.TestWithCases;
+
+class TimeSpecimenTest {
+
+    @Test
+    void onlyTemporalTypes() {
+        assertThatThrownBy( () -> new TimeSpecimen( Map.class ) )
+                .isInstanceOf( IllegalArgumentException.class )
+                .hasMessageContaining( "type: " + Map.class.getName() );
+    }
+
+    @Test
+    void typeIsRequired() {
+        assertThatThrownBy( () -> new TimeSpecimen<>( null ) )
+                .isInstanceOf( IllegalArgumentException.class )
+                .hasMessageContaining( "type: null" );
+    }
+
+    @TestWithCases
+    @TestCase(class1 = Duration.class)
+    @TestCase(class1 = Period.class)
+    @TestCase(class1 = MonthDay.class)
+    @TestCase(class1 = ZoneId.class)
+    @TestCase(class1 = ZoneOffset.class)
+    void createDuration(Class type) {
+        var sut = new TimeSpecimen<>( type );
+
+        var actual = sut.create();
+
+        assertThat(actual).isInstanceOf(type);
+        assertThat(actual.toString()).isNotEmpty();
+    }
+
+    @Test
+    void throwsExceptionForUnknownType() {
+        assertThatThrownBy( () -> new TimeSpecimen<>( Mockito.mock( TemporalAmount.class ).getClass() ).create() )
+                .isInstanceOf( SpecimenException.class )
+                .hasMessageContaining( "Unsupported type:" );
+    }
+}

--- a/src/test/java/com/github/nylle/javafixture/specimen/TimeSpecimenTest.java
+++ b/src/test/java/com/github/nylle/javafixture/specimen/TimeSpecimenTest.java
@@ -8,6 +8,7 @@ import java.time.MonthDay;
 import java.time.Period;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
+import java.time.chrono.JapaneseEra;
 import java.time.temporal.TemporalAmount;
 import java.util.Map;
 
@@ -19,10 +20,9 @@ import com.github.nylle.javafixture.parameterized.TestCase;
 import com.github.nylle.javafixture.parameterized.TestWithCases;
 
 class TimeSpecimenTest {
-
     @Test
     void onlyTemporalTypes() {
-        assertThatThrownBy( () -> new TimeSpecimen( Map.class ) )
+        assertThatThrownBy( () -> new TimeSpecimen<>( Map.class ) )
                 .isInstanceOf( IllegalArgumentException.class )
                 .hasMessageContaining( "type: " + Map.class.getName() );
     }
@@ -36,8 +36,9 @@ class TimeSpecimenTest {
 
     @TestWithCases
     @TestCase(class1 = Duration.class)
-    @TestCase(class1 = Period.class)
+    @TestCase(class1 = JapaneseEra.class)
     @TestCase(class1 = MonthDay.class)
+    @TestCase(class1 = Period.class)
     @TestCase(class1 = ZoneId.class)
     @TestCase(class1 = ZoneOffset.class)
     void createDuration(Class type) {


### PR DESCRIPTION
That should cover most of the cases where JavaFIxture is used.
There are still some exotic classes like java.time.chrono.Era which need to be covered