### PR TITLE
JAVAFIXTURE-25: Add support for generic interfaces

### DIFF
--- a/src/main/java/com/github/nylle/javafixture/ProxyFactory.java
+++ b/src/main/java/com/github/nylle/javafixture/ProxyFactory.java
@@ -1,0 +1,53 @@
+package com.github.nylle.javafixture;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Proxy;
+import java.lang.reflect.Type;
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.github.nylle.javafixture.ReflectionHelper.isParameterizedType;
+import static java.util.Arrays.stream;
+import static java.util.stream.Collectors.toList;
+
+public class ProxyFactory implements InvocationHandler {
+
+    private final SpecimenFactory specimenFactory;
+    private final Map<String, Object> methodResults = new HashMap<>();
+    private final Map<String, ISpecimen<?>> specimens;
+
+    private ProxyFactory(final SpecimenFactory specimenFactory, final Map<String, ISpecimen<?>> specimens) {
+        this.specimenFactory = specimenFactory;
+        this.specimens = specimens;
+    }
+
+    public static <T> Object create(final Class<T> type, final SpecimenFactory specimenFactory) {
+        return Proxy.newProxyInstance(type.getClassLoader(), new Class[]{type}, new ProxyFactory(specimenFactory, new HashMap<>()));
+    }
+
+    public static <T> Object createGeneric(final Class<T> type, final SpecimenFactory specimenFactory, final Map<String, ISpecimen<?>> specimens) {
+        return Proxy.newProxyInstance(type.getClassLoader(), new Class[]{type}, new ProxyFactory(specimenFactory, specimens));
+    }
+
+    @Override
+    public Object invoke(final Object proxy, final Method method, final Object[] args) {
+        return method.getReturnType() == void.class
+                ? null
+                : methodResults.computeIfAbsent(method.toString(), key -> specimens.getOrDefault(method.getGenericReturnType().getTypeName(), resolveSpecimen(method)).create());
+    }
+
+    private ISpecimen<?> resolveSpecimen(final Method method) {
+        return isParameterizedType(method.getGenericReturnType())
+                ? specimenFactory.build(method.getReturnType(), stream(((ParameterizedType) method.getGenericReturnType()).getActualTypeArguments()).map(t -> getParameterClass(t)).collect(toList()))
+                : specimenFactory.build(method.getReturnType());
+    }
+
+    private Class<?> getParameterClass(Type type) {
+        var candidate = specimens.get(type.getTypeName());
+        return candidate != null
+                ? candidate.create().getClass()
+                : (Class<?>) type;
+    }
+}

--- a/src/main/java/com/github/nylle/javafixture/SpecimenFactory.java
+++ b/src/main/java/com/github/nylle/javafixture/SpecimenFactory.java
@@ -11,6 +11,7 @@ import com.github.nylle.javafixture.specimen.PrimitiveSpecimen;
 import com.github.nylle.javafixture.specimen.TimeSpecimen;
 
 import java.lang.reflect.Type;
+import java.util.List;
 
 import static com.github.nylle.javafixture.ReflectionHelper.isParameterizedType;
 import static java.util.Arrays.stream;
@@ -74,6 +75,10 @@ public class SpecimenFactory {
         }
 
         return new GenericSpecimen<>(type, context, this, asSpecimen(genericType));
+    }
+
+    public <T> ISpecimen<T> build(final Class<T> type, final List<Class<?>> genericTypes) {
+         return new GenericSpecimen<>(type, context, this, genericTypes.stream().map(t -> asSpecimen(t)).toArray(size -> new ISpecimen<?>[size]));
     }
 
     private ISpecimen<?> asSpecimen(Type t) {

--- a/src/main/java/com/github/nylle/javafixture/extension/JavaFixtureExtension.java
+++ b/src/main/java/com/github/nylle/javafixture/extension/JavaFixtureExtension.java
@@ -1,10 +1,18 @@
 package com.github.nylle.javafixture.extension;
 
-import com.github.nylle.javafixture.JavaFixture;
+import com.github.nylle.javafixture.Configuration;
+import com.github.nylle.javafixture.Context;
+import com.github.nylle.javafixture.ISpecimen;
+import com.github.nylle.javafixture.SpecimenFactory;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.ParameterContext;
 import org.junit.jupiter.api.extension.ParameterResolutionException;
 import org.junit.jupiter.api.extension.ParameterResolver;
+
+import java.lang.reflect.Type;
+
+import static com.github.nylle.javafixture.ReflectionHelper.castToClass;
+import static com.github.nylle.javafixture.ReflectionHelper.isParameterizedType;
 
 public class JavaFixtureExtension implements ParameterResolver {
     @Override
@@ -14,7 +22,13 @@ public class JavaFixtureExtension implements ParameterResolver {
 
     @Override
     public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext) throws ParameterResolutionException {
-        return new JavaFixture().create(parameterContext.getParameter().getType());
+        return createSpecimen(parameterContext.getParameter().getParameterizedType()).create();
+    }
+
+    private ISpecimen<?> createSpecimen(Type genericType) {
+        return isParameterizedType(genericType)
+                ? new SpecimenFactory(new Context(new Configuration())).build((Class<?>) castToClass(genericType), genericType)
+                : new SpecimenFactory(new Context(new Configuration())).build((Class<?>) castToClass(genericType));
     }
 }
 

--- a/src/main/java/com/github/nylle/javafixture/extension/JavaFixtureProvider.java
+++ b/src/main/java/com/github/nylle/javafixture/extension/JavaFixtureProvider.java
@@ -1,15 +1,20 @@
 package com.github.nylle.javafixture.extension;
 
-import static java.util.Arrays.stream;
-
-import java.util.stream.Stream;
-
+import com.github.nylle.javafixture.Configuration;
+import com.github.nylle.javafixture.Context;
+import com.github.nylle.javafixture.ISpecimen;
+import com.github.nylle.javafixture.SpecimenFactory;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.support.AnnotationConsumer;
 
-import com.github.nylle.javafixture.JavaFixture;
+import java.lang.reflect.Type;
+import java.util.stream.Stream;
+
+import static com.github.nylle.javafixture.ReflectionHelper.castToClass;
+import static com.github.nylle.javafixture.ReflectionHelper.isParameterizedType;
+import static java.util.Arrays.stream;
 
 public class JavaFixtureProvider implements ArgumentsProvider, AnnotationConsumer<TestWithFixture> {
     @Override
@@ -17,8 +22,12 @@ public class JavaFixtureProvider implements ArgumentsProvider, AnnotationConsume
 
     @Override
     public Stream<Arguments> provideArguments(ExtensionContext context) {
+        return Stream.of(Arguments.of(context.getTestMethod().stream().flatMap(m -> stream(m.getGenericParameterTypes()).map(t -> createSpecimen(t).create())).toArray()));
+    }
 
-        return Stream.of(Arguments.of(context.getTestMethod().stream().flatMap(m -> stream(m.getParameterTypes()).map(c -> new JavaFixture().create(c))).toArray()));
-
+    private ISpecimen<?> createSpecimen(Type genericType) {
+        return isParameterizedType(genericType)
+                ? new SpecimenFactory(new Context(new Configuration())).build((Class<?>) castToClass(genericType), genericType)
+                : new SpecimenFactory(new Context(new Configuration())).build((Class<?>) castToClass(genericType));
     }
 }

--- a/src/main/java/com/github/nylle/javafixture/specimen/GenericSpecimen.java
+++ b/src/main/java/com/github/nylle/javafixture/specimen/GenericSpecimen.java
@@ -3,6 +3,7 @@ package com.github.nylle.javafixture.specimen;
 import com.github.nylle.javafixture.Context;
 import com.github.nylle.javafixture.CustomizationContext;
 import com.github.nylle.javafixture.ISpecimen;
+import com.github.nylle.javafixture.ProxyFactory;
 import com.github.nylle.javafixture.ReflectionHelper;
 import com.github.nylle.javafixture.SpecimenFactory;
 import com.github.nylle.javafixture.SpecimenType;
@@ -76,6 +77,10 @@ public class GenericSpecimen<T> implements ISpecimen<T> {
 
         if (context.isCached(specimenType)) {
             return (T) context.cached(specimenType);
+        }
+
+        if(type.isInterface()) {
+            return (T) context.cached(specimenType, ProxyFactory.createGeneric(type, specimenFactory, specimens));
         }
 
         var result = context.cached(specimenType, newInstance(type));

--- a/src/main/java/com/github/nylle/javafixture/specimen/InterfaceSpecimen.java
+++ b/src/main/java/com/github/nylle/javafixture/specimen/InterfaceSpecimen.java
@@ -2,16 +2,11 @@ package com.github.nylle.javafixture.specimen;
 
 import com.github.nylle.javafixture.Context;
 import com.github.nylle.javafixture.CustomizationContext;
-import com.github.nylle.javafixture.ReflectionHelper;
 import com.github.nylle.javafixture.ISpecimen;
+import com.github.nylle.javafixture.ProxyFactory;
+import com.github.nylle.javafixture.ReflectionHelper;
 import com.github.nylle.javafixture.SpecimenFactory;
 import com.github.nylle.javafixture.SpecimenType;
-
-import java.lang.reflect.InvocationHandler;
-import java.lang.reflect.Method;
-import java.lang.reflect.Proxy;
-import java.util.HashMap;
-import java.util.Map;
 
 import static com.github.nylle.javafixture.CustomizationContext.noContext;
 
@@ -57,23 +52,9 @@ public class InterfaceSpecimen<T> implements ISpecimen<T> {
             return (T) context.cached(specimenType);
         }
 
-        return (T) context.cached(specimenType, Proxy.newProxyInstance(type.getClassLoader(), new Class[]{type}, new GenericInvocationHandler()));
+        return (T) context.cached(specimenType, ProxyFactory.create(type, specimenFactory));
     }
 
-    class GenericInvocationHandler implements InvocationHandler {
-
-        private Map<String, Object> methodResults = new HashMap<>();
-
-        @Override
-        public Object invoke(final Object proxy, final Method method, final Object[] args) {
-            if(method.getReturnType() != void.class) {
-                methodResults.computeIfAbsent(method.toString(), x -> specimenFactory.build(method.getReturnType()).create());
-                return methodResults.get(method.toString());
-            }
-
-            return null;
-        }
-    }
 
 
 }

--- a/src/test/java/com/github/nylle/javafixture/JavaFixtureTest.java
+++ b/src/test/java/com/github/nylle/javafixture/JavaFixtureTest.java
@@ -87,6 +87,20 @@ class JavaFixtureTest {
     }
 
     @Test
+    void canAddManyTo() {
+        JavaFixture fixture = new JavaFixture(configuration);
+
+        List<TestPrimitive> result = new ArrayList<>();
+        result.add(new TestPrimitive());
+
+        fixture.addManyTo(result, TestPrimitive.class);
+
+        assertThat(result).isNotNull();
+        assertThat(result.size()).isEqualTo(4);
+        assertThat(result.get(1)).isInstanceOf(TestPrimitive.class);
+    }
+
+    @Test
     void canCreateManyWithCustomization() {
         JavaFixture fixture = new JavaFixture(configuration);
 
@@ -117,20 +131,6 @@ class JavaFixtureTest {
 
         assertThat(first.getPrimitive()).isNotEqualTo(second.getPrimitive());
         assertThat(second.getPrimitive()).isNotEqualTo(third.getPrimitive());
-    }
-
-    @Test
-    void canAddManyTo() {
-        JavaFixture fixture = new JavaFixture(configuration);
-
-        List<TestPrimitive> result = new ArrayList<>();
-        result.add(new TestPrimitive());
-
-        fixture.addManyTo(result, TestPrimitive.class);
-
-        assertThat(result).isNotNull();
-        assertThat(result.size()).isEqualTo(4);
-        assertThat(result.get(1)).isInstanceOf(TestPrimitive.class);
     }
 
     @Test
@@ -179,6 +179,16 @@ class JavaFixtureTest {
     }
 
     @Test
+    void canPerformAction() {
+        JavaFixture fixture = new JavaFixture(configuration);
+
+        ContractPosition cp = fixture.create(ContractPosition.class);
+        Contract contract = fixture.build(Contract.class).with(x -> x.addContractPosition(cp)).with(x -> x.setBaseContractPosition(cp)).create();
+
+        assertThat(contract.getContractPositions().contains(contract.getBaseContractPosition())).isTrue();
+    }
+
+    @Test
     void canCreateComplexModel() {
         JavaFixture fixture = new JavaFixture(configuration);
 
@@ -210,16 +220,6 @@ class JavaFixtureTest {
         assertThat(result.getStackTrace().length).isGreaterThan(0);
         assertThat(result.getStackTrace()[0]).isInstanceOf(StackTraceElement.class);
         assertThat(result.getCause()).isNull(); //if cause == this, the getter returns null
-    }
-
-    @Test
-    void canPerformAction() {
-        JavaFixture fixture = new JavaFixture(configuration);
-
-        ContractPosition cp = fixture.create(ContractPosition.class);
-        Contract contract = fixture.build(Contract.class).with(x -> x.addContractPosition(cp)).with(x -> x.setBaseContractPosition(cp)).create();
-
-        assertThat(contract.getContractPositions().contains(contract.getBaseContractPosition())).isTrue();
     }
 
     @Test

--- a/src/test/java/com/github/nylle/javafixture/JavaFixtureTest.java
+++ b/src/test/java/com/github/nylle/javafixture/JavaFixtureTest.java
@@ -1,7 +1,10 @@
 package com.github.nylle.javafixture;
 
+import com.github.nylle.javafixture.testobjects.ITestGeneric;
+import com.github.nylle.javafixture.testobjects.ITestGenericInside;
 import com.github.nylle.javafixture.testobjects.TestObjectGeneric;
 import com.github.nylle.javafixture.testobjects.TestObjectWithGenerics;
+import com.github.nylle.javafixture.testobjects.TestObjectWithNestedGenericInterfaces;
 import com.github.nylle.javafixture.testobjects.TestObjectWithNestedGenerics;
 import com.github.nylle.javafixture.testobjects.TestObjectWithNestedMapsAndLists;
 import com.github.nylle.javafixture.testobjects.TestObjectWithoutDefaultConstructor;
@@ -22,6 +25,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static com.github.nylle.javafixture.JavaFixture.fixture;
 import static org.assertj.core.api.Assertions.assertThat;
 
 
@@ -297,5 +301,31 @@ class JavaFixtureTest {
         assertThat(result.getGenericOptional().getU()).isInstanceOf(Optional.class);
         assertThat(result.getGenericOptional().getU()).isPresent();
         assertThat(result.getGenericOptional().getU().get()).isInstanceOf(Integer.class);
+    }
+
+    @Test
+    void canCreateNestedParameterizedInterfaces() {
+        final var result = fixture().create(TestObjectWithNestedGenericInterfaces.class);
+
+        assertThat(result).isInstanceOf(TestObjectWithNestedGenericInterfaces.class);
+
+        assertThat(result.getTestGeneric()).isInstanceOf(ITestGeneric.class);
+        assertThat(result.getTestGeneric().publicField).isInstanceOf(Integer.class);
+
+        assertThat(result.getTestGeneric().getT()).isInstanceOf(String.class);
+        assertThat(result.getTestGeneric().getU()).isInstanceOf(ITestGenericInside.class);
+
+        assertThat(result.getTestGeneric().getU().getOptionalBoolean()).isInstanceOf(Optional.class);
+        assertThat(result.getTestGeneric().getU().getOptionalBoolean()).isPresent();
+        assertThat(result.getTestGeneric().getU().getOptionalBoolean().get()).isInstanceOf(Boolean.class);
+
+        assertThat(result.getTestGeneric().getU().getOptionalT()).isInstanceOf(Optional.class);
+        assertThat(result.getTestGeneric().getU().getOptionalT()).isPresent();
+        assertThat(result.getTestGeneric().getU().getOptionalT().get()).isInstanceOf(Integer.class);
+
+        assertThat(result.getTestGeneric().getU().getTestGeneric()).isInstanceOf(TestObjectGeneric.class);
+        assertThat(result.getTestGeneric().getU().getTestGeneric().getT()).isInstanceOf(String.class);
+        assertThat(result.getTestGeneric().getU().getTestGeneric().getU()).isInstanceOf(Integer.class);
+
     }
 }

--- a/src/test/java/com/github/nylle/javafixture/extension/JavaFixtureClassExtensionTest.java
+++ b/src/test/java/com/github/nylle/javafixture/extension/JavaFixtureClassExtensionTest.java
@@ -5,6 +5,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+import java.util.Optional;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith(JavaFixtureExtension.class)
@@ -12,23 +14,30 @@ public class JavaFixtureClassExtensionTest {
 
     private Contract contract;
     private int intValue;
+    private Optional<String> optionalString;
 
     @BeforeEach
-    void setup(Contract contract, int intValue) {
+    void setup(Contract contract, int intValue, Optional<String> optionalString) {
         this.contract = contract;
         this.intValue = intValue;
+        this.optionalString = optionalString;
     }
 
     @Test
     void injectParameterIntoSetup() {
         assertThat(contract.getId()).isBetween(Long.MIN_VALUE, Long.MAX_VALUE);
         assertThat(intValue).isBetween(Integer.MIN_VALUE, Integer.MAX_VALUE);
+        assertThat(optionalString).isInstanceOf(Optional.class);
+        assertThat(optionalString).isPresent();
+        assertThat(optionalString.get()).isInstanceOf(String.class);
     }
 
     @Test
-    void injectParameterViaClassExtension(Contract contract, int intValue) {
+    void injectParameterViaClassExtension(Contract contract, int intValue, Optional<String> optionalString) {
         assertThat(contract.getId()).isBetween(Long.MIN_VALUE, Long.MAX_VALUE);
         assertThat(intValue).isBetween(Integer.MIN_VALUE, Integer.MAX_VALUE);
+        assertThat(optionalString).isInstanceOf(Optional.class);
+        assertThat(optionalString).isPresent();
+        assertThat(optionalString.get()).isInstanceOf(String.class);
     }
-
 }

--- a/src/test/java/com/github/nylle/javafixture/extension/TestWithFixtureTest.java
+++ b/src/test/java/com/github/nylle/javafixture/extension/TestWithFixtureTest.java
@@ -2,13 +2,17 @@ package com.github.nylle.javafixture.extension;
 
 import com.github.nylle.javafixture.testobjects.example.Contract;
 
+import java.util.Optional;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestWithFixtureTest {
     @TestWithFixture
-    void injectParameterViaMethodExtension(Contract contract, int intValue) {
+    void injectParameterViaMethodExtension(Contract contract, int intValue, Optional<String> optionalString) {
         assertThat(contract.getId()).isBetween(Long.MIN_VALUE, Long.MAX_VALUE);
         assertThat(intValue).isBetween(Integer.MIN_VALUE, Integer.MAX_VALUE);
+        assertThat(optionalString).isInstanceOf(Optional.class);
+        assertThat(optionalString).isPresent();
+        assertThat(optionalString.get()).isInstanceOf(String.class);
     }
-
 }

--- a/src/test/java/com/github/nylle/javafixture/testobjects/ITestGeneric.java
+++ b/src/test/java/com/github/nylle/javafixture/testobjects/ITestGeneric.java
@@ -1,0 +1,12 @@
+package com.github.nylle.javafixture.testobjects;
+
+public interface ITestGeneric<T, U> {
+    int publicField = 1;
+
+    T getT();
+
+    U getU();
+
+    void setT(T value);
+
+}

--- a/src/test/java/com/github/nylle/javafixture/testobjects/ITestGenericInside.java
+++ b/src/test/java/com/github/nylle/javafixture/testobjects/ITestGenericInside.java
@@ -1,0 +1,13 @@
+package com.github.nylle.javafixture.testobjects;
+
+import java.util.Optional;
+
+public interface ITestGenericInside<T> {
+
+    Optional<Boolean> getOptionalBoolean();
+
+    Optional<T> getOptionalT();
+
+    TestObjectGeneric<String, T> getTestGeneric();
+
+}

--- a/src/test/java/com/github/nylle/javafixture/testobjects/TestObjectWithNestedGenericInterfaces.java
+++ b/src/test/java/com/github/nylle/javafixture/testobjects/TestObjectWithNestedGenericInterfaces.java
@@ -1,0 +1,10 @@
+package com.github.nylle.javafixture.testobjects;
+
+public class TestObjectWithNestedGenericInterfaces {
+
+    private ITestGeneric<String, ITestGenericInside<Integer>> testGeneric;
+
+    public ITestGeneric<String, ITestGenericInside<Integer>> getTestGeneric() {
+        return testGeneric;
+    }
+}


### PR DESCRIPTION
While adding support for generics, the interfaces have been forgotten.
Now, generic interfaces like IPair<K, V> can be proxied.