### PR TITLE
JAVAFIXTURE-12: Allow Use of Random Constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,12 +196,14 @@ The values below are the default values, used when no configuration is provided.
 var config = Configuration.configure()
                     .collectionSizeRange(2, 10)
                     .streamSize(3)
+                    .usePositiveNumbersOnly(false)
                     .clock(Clock.fixed(Instant.now(), ZoneOffset.UTC));
 
 var fixture = new Fixture(config);
 ```
 - `collectionSizeRange` determines the range from which a random collection size will be picked when creating any collection, map or array
 - `streamSize` determines the number of objects to be returned when using `Stream<T> Fixture.createMany(Class<T>)`
+- `usePositiveNumbersOnly` defines whether to generate only positive numbers including 0 for `short`, `int`, `long`, `float`, and `double`
 - `clock` sets the clock to use when creating time-based values
 
 ## JUnit5 Support

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ The purpose of this project is to generate full object graphs for use in test su
 - [Getting Started](#getting-started)
 - [Usage](#usage)
 - [Generics](#generics)
+- [Random Constructor](#constructor)
 - [Configuration](#configuration)
 - [JUnit5 Support](#junit5-support)
 - [Parameterized Tests](#parameterized-tests)
@@ -179,6 +180,15 @@ Optional result = fixture.create(SpecimenType.fromClass(Optional.class));
 
 Optional result = fixture.create(Optional.class); // convenience method for above
 ```
+
+## Constructor
+There might be some cases when you want to create an object not by instantiating it and setting all fields, but by calling one of its constructors and feeding it random values.
+```java
+var result = fixture.construct(new SpecimenType<MyGeneric<String>>(){});
+
+var result = fixture.construct(String.class);
+```
+_Keep in mind that only public constructors are allowed._
 
 ## Configuration
 The values below are the default values, used when no configuration is provided.

--- a/src/main/java/com/github/nylle/javafixture/CustomizationContext.java
+++ b/src/main/java/com/github/nylle/javafixture/CustomizationContext.java
@@ -8,16 +8,25 @@ import java.util.Map;
 public class CustomizationContext {
     private final List<String> ignoredFields;
     private final Map<String, Object> customFields;
+    private final boolean useRandomConstructor;
 
 
     private CustomizationContext() {
         ignoredFields = Collections.emptyList();
         customFields = new HashMap<>();
+        useRandomConstructor = false;
+    }
+
+    public CustomizationContext(final boolean useRandomConstructor) {
+        ignoredFields = Collections.emptyList();
+        customFields = new HashMap<>();
+        this.useRandomConstructor = useRandomConstructor;
     }
 
     public CustomizationContext(final List<String> ignoredFields, final Map<String, Object> customFields) {
         this.ignoredFields = ignoredFields;
         this.customFields = customFields;
+        this.useRandomConstructor = false;
     }
 
     public static CustomizationContext noContext() {
@@ -30,5 +39,9 @@ public class CustomizationContext {
 
     public Map<String, Object> getCustomFields() {
         return customFields;
+    }
+
+    public boolean useRandomConstructor() {
+        return useRandomConstructor;
     }
 }

--- a/src/main/java/com/github/nylle/javafixture/Fixture.java
+++ b/src/main/java/com/github/nylle/javafixture/Fixture.java
@@ -67,6 +67,28 @@ public class Fixture {
     }
 
     /**
+     * Creates a new object of the specified type, using a random constructor if available
+     *
+     * @param type the {@code Class<T>} based on which the object is created
+     * @param <T> the type of the object to be created
+     * @return a new object of the specified type {@code T}
+     */
+    public <T> T createThroughRandomConstructor(final Class<T> type) {
+        return new SpecimenBuilder<T>(SpecimenType.fromClass(type), configuration).createThroughRandomConstructor();
+    }
+
+    /**
+     * Creates a new object of the specified type, using a random constructor if available
+     *
+     * @param type the {@code SpecimenType<T>} based on which the object is created
+     * @param <T> the type of the object to be created
+     * @return a new object of the specified type {@code T}
+     */
+    public <T> T createThroughRandomConstructor(final SpecimenType<T> type) {
+        return new SpecimenBuilder<>(type, configuration).createThroughRandomConstructor();
+    }
+
+    /**
      * Creates a {@code Stream} of objects of the specified type, recursively populated with random values
      *
      * @param type the {@code Class<T>} based on which the objects are created

--- a/src/main/java/com/github/nylle/javafixture/Fixture.java
+++ b/src/main/java/com/github/nylle/javafixture/Fixture.java
@@ -73,8 +73,8 @@ public class Fixture {
      * @param <T> the type of the object to be created
      * @return a new object of the specified type {@code T}
      */
-    public <T> T createThroughRandomConstructor(final Class<T> type) {
-        return new SpecimenBuilder<T>(SpecimenType.fromClass(type), configuration).createThroughRandomConstructor();
+    public <T> T construct(final Class<T> type) {
+        return new SpecimenBuilder<T>(SpecimenType.fromClass(type), configuration).construct();
     }
 
     /**
@@ -84,8 +84,8 @@ public class Fixture {
      * @param <T> the type of the object to be created
      * @return a new object of the specified type {@code T}
      */
-    public <T> T createThroughRandomConstructor(final SpecimenType<T> type) {
-        return new SpecimenBuilder<>(type, configuration).createThroughRandomConstructor();
+    public <T> T construct(final SpecimenType<T> type) {
+        return new SpecimenBuilder<>(type, configuration).construct();
     }
 
     /**

--- a/src/main/java/com/github/nylle/javafixture/InstanceFactory.java
+++ b/src/main/java/com/github/nylle/javafixture/InstanceFactory.java
@@ -43,7 +43,8 @@ public class InstanceFactory {
                             .map(s -> s.create())
                             .toArray(size -> new Object[size]));
         } catch (Exception e) {
-            throw new SpecimenException(format("Unable to construct class %s with constructor %s", type.asClass(), constructor.toString()), e);
+            throw new SpecimenException(format("Unable to construct class %s with constructor %s: %s",
+                    type.asClass(), constructor.toString(), e.getMessage()), e);
         }
     }
 

--- a/src/main/java/com/github/nylle/javafixture/InstanceFactory.java
+++ b/src/main/java/com/github/nylle/javafixture/InstanceFactory.java
@@ -1,0 +1,63 @@
+package com.github.nylle.javafixture;
+
+import org.objenesis.Objenesis;
+import org.objenesis.ObjenesisStd;
+import org.objenesis.instantiator.ObjectInstantiator;
+
+import java.lang.reflect.Proxy;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Random;
+
+import static java.util.Arrays.stream;
+
+public class InstanceFactory {
+
+    private final SpecimenFactory specimenFactory;
+    private final Random random;
+
+    public InstanceFactory(SpecimenFactory specimenFactory) {
+        this.specimenFactory = specimenFactory;
+        this.random = new Random();
+    }
+
+    public <T> T construct(final SpecimenType<T> type) {
+        var constructors = type.asClass().getConstructors();
+
+        if (constructors.length == 0) {
+            return instantiate(type);
+        }
+
+        try {
+            return (T) constructors[random.nextInt(constructors.length)].newInstance(
+                    stream(constructors[random.nextInt(constructors.length)].getGenericParameterTypes())
+                            .map(t -> specimenFactory.build(SpecimenType.fromClass(t)))
+                            .map(s -> s.create())
+                            .toArray(size -> new Object[size]));
+        } catch (Exception e) {
+            return instantiate(type);
+        }
+    }
+
+    public <T> T instantiate(final SpecimenType<T> type) {
+        try {
+            return type.asClass().getDeclaredConstructor().newInstance();
+        } catch (Exception e) {
+            return (T) ((ObjectInstantiator) ((Objenesis) new ObjenesisStd()).getInstantiatorOf(type.asClass())).newInstance();
+        }
+    }
+
+    public <T> Object proxy(final SpecimenType<T> type) {
+        return Proxy.newProxyInstance(
+                type.asClass().getClassLoader(),
+                new Class[]{type.asClass()},
+                new ProxyInvocationHandler(specimenFactory, new HashMap<>()));
+    }
+
+    public <T> Object proxy(final SpecimenType<T> type, final Map<String, ISpecimen<?>> specimens) {
+        return Proxy.newProxyInstance(
+                type.asClass().getClassLoader(),
+                new Class[]{type.asClass()},
+                new ProxyInvocationHandler(specimenFactory, specimens));
+    }
+}

--- a/src/main/java/com/github/nylle/javafixture/InstanceFactory.java
+++ b/src/main/java/com/github/nylle/javafixture/InstanceFactory.java
@@ -4,12 +4,16 @@ import org.objenesis.Objenesis;
 import org.objenesis.ObjenesisStd;
 import org.objenesis.instantiator.ObjectInstantiator;
 
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Modifier;
 import java.lang.reflect.Proxy;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
 
+import static java.lang.String.format;
 import static java.util.Arrays.stream;
+import static java.util.stream.Collectors.toList;
 
 public class InstanceFactory {
 
@@ -22,20 +26,24 @@ public class InstanceFactory {
     }
 
     public <T> T construct(final SpecimenType<T> type) {
-        var constructors = type.asClass().getConstructors();
+        var constructors = stream(type.asClass().getConstructors())
+                .filter(x -> Modifier.isPublic(x.getModifiers()))
+                .collect(toList());
 
-        if (constructors.length == 0) {
-            return instantiate(type);
+        if (constructors.isEmpty()) {
+            throw new SpecimenException(format("Cannot construct %s: no public constructor found", type.asClass()));
         }
 
+        Constructor<?> constructor = constructors.get(random.nextInt(constructors.size()));
+
         try {
-            return (T) constructors[random.nextInt(constructors.length)].newInstance(
-                    stream(constructors[random.nextInt(constructors.length)].getGenericParameterTypes())
+            return (T) constructor.newInstance(
+                    stream(constructor.getGenericParameterTypes())
                             .map(t -> specimenFactory.build(SpecimenType.fromClass(t)))
                             .map(s -> s.create())
                             .toArray(size -> new Object[size]));
         } catch (Exception e) {
-            return instantiate(type);
+            throw new SpecimenException(format("Unable to construct class %s with constructor %s", type.asClass(), constructor.toString()), e);
         }
     }
 

--- a/src/main/java/com/github/nylle/javafixture/ProxyInvocationHandler.java
+++ b/src/main/java/com/github/nylle/javafixture/ProxyInvocationHandler.java
@@ -3,30 +3,21 @@ package com.github.nylle.javafixture;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
-import java.lang.reflect.Proxy;
 import java.lang.reflect.Type;
 import java.util.HashMap;
 import java.util.Map;
 
 import static java.util.Arrays.stream;
 
-public class ProxyFactory implements InvocationHandler {
+public class ProxyInvocationHandler implements InvocationHandler {
 
     private final SpecimenFactory specimenFactory;
     private final Map<String, Object> methodResults = new HashMap<>();
     private final Map<String, ISpecimen<?>> specimens;
 
-    private ProxyFactory(final SpecimenFactory specimenFactory, final Map<String, ISpecimen<?>> specimens) {
+    public ProxyInvocationHandler(final SpecimenFactory specimenFactory, final Map<String, ISpecimen<?>> specimens) {
         this.specimenFactory = specimenFactory;
         this.specimens = specimens;
-    }
-
-    public static <T> Object create(final SpecimenType<T> type, final SpecimenFactory specimenFactory) {
-        return Proxy.newProxyInstance(type.asClass().getClassLoader(), new Class[]{type.asClass()}, new ProxyFactory(specimenFactory, new HashMap<>()));
-    }
-
-    public static <T> Object create(final Class<T> type, final SpecimenFactory specimenFactory, final Map<String, ISpecimen<?>> specimens) {
-        return Proxy.newProxyInstance(type.getClassLoader(), new Class[]{type}, new ProxyFactory(specimenFactory, specimens));
     }
 
     @Override

--- a/src/main/java/com/github/nylle/javafixture/SpecimenBuilder.java
+++ b/src/main/java/com/github/nylle/javafixture/SpecimenBuilder.java
@@ -86,6 +86,10 @@ public class SpecimenBuilder<T> implements ISpecimenBuilder<T> {
         return this;
     }
 
+    T createThroughRandomConstructor() {
+        return new SpecimenFactory(new Context(configuration)).build(type).create(new CustomizationContext(true));
+    }
+
     private T customize(T instance) {
         functions.forEach(f -> f.accept(instance));
         return instance;

--- a/src/main/java/com/github/nylle/javafixture/SpecimenBuilder.java
+++ b/src/main/java/com/github/nylle/javafixture/SpecimenBuilder.java
@@ -86,7 +86,7 @@ public class SpecimenBuilder<T> implements ISpecimenBuilder<T> {
         return this;
     }
 
-    T createThroughRandomConstructor() {
+    T construct() {
         return new SpecimenFactory(new Context(configuration)).build(type).create(new CustomizationContext(true));
     }
 

--- a/src/main/java/com/github/nylle/javafixture/SpecimenType.java
+++ b/src/main/java/com/github/nylle/javafixture/SpecimenType.java
@@ -1,9 +1,5 @@
 package com.github.nylle.javafixture;
 
-import org.objenesis.Objenesis;
-import org.objenesis.ObjenesisStd;
-import org.objenesis.instantiator.ObjectInstantiator;
-
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.lang.reflect.WildcardType;
@@ -49,14 +45,6 @@ public class SpecimenType<T> extends TypeCapture<T> {
         }
 
         throw new SpecimenTypeException(format("%s is not a ParameterizedType", type));
-    }
-
-    public T toInstance() {
-        try {
-            return asClass().getDeclaredConstructor().newInstance();
-        } catch (Exception e) {
-            return (T) ((ObjectInstantiator) ((Objenesis) new ObjenesisStd()).getInstantiatorOf(asClass())).newInstance();
-        }
     }
 
     public Type[] getGenericTypeArguments() {

--- a/src/main/java/com/github/nylle/javafixture/specimen/GenericSpecimen.java
+++ b/src/main/java/com/github/nylle/javafixture/specimen/GenericSpecimen.java
@@ -77,6 +77,10 @@ public class GenericSpecimen<T> implements ISpecimen<T> {
             return (T) context.cached(type, instanceFactory.proxy(type, specimens));
         }
 
+        if(customizationContext.useRandomConstructor()) {
+            return context.cached(type, instanceFactory.construct(type));
+        }
+
         var result = context.cached(type, instanceFactory.instantiate(type));
 
         stream(type.asClass().getDeclaredFields())

--- a/src/main/java/com/github/nylle/javafixture/specimen/GenericSpecimen.java
+++ b/src/main/java/com/github/nylle/javafixture/specimen/GenericSpecimen.java
@@ -3,7 +3,7 @@ package com.github.nylle.javafixture.specimen;
 import com.github.nylle.javafixture.Context;
 import com.github.nylle.javafixture.CustomizationContext;
 import com.github.nylle.javafixture.ISpecimen;
-import com.github.nylle.javafixture.ProxyFactory;
+import com.github.nylle.javafixture.InstanceFactory;
 import com.github.nylle.javafixture.ReflectionHelper;
 import com.github.nylle.javafixture.SpecimenFactory;
 import com.github.nylle.javafixture.SpecimenType;
@@ -21,6 +21,7 @@ public class GenericSpecimen<T> implements ISpecimen<T> {
     private final SpecimenType<T> type;
     private final Context context;
     private final SpecimenFactory specimenFactory;
+    private final InstanceFactory instanceFactory;
     private final Map<String, ISpecimen<?>> specimens;
 
     public GenericSpecimen(final SpecimenType<T> type, final Context context, final SpecimenFactory specimenFactory) throws IllegalArgumentException {
@@ -48,6 +49,7 @@ public class GenericSpecimen<T> implements ISpecimen<T> {
         this.type = type;
         this.context = context;
         this.specimenFactory = specimenFactory;
+        this.instanceFactory = new InstanceFactory(specimenFactory);
 
         this.specimens = IntStream.range(0, type.getGenericTypeArguments().length)
                 .boxed()
@@ -72,10 +74,10 @@ public class GenericSpecimen<T> implements ISpecimen<T> {
         }
 
         if(type.isInterface()) {
-            return (T) context.cached(type, ProxyFactory.create(type.asClass(), specimenFactory, specimens));
+            return (T) context.cached(type, instanceFactory.proxy(type, specimens));
         }
 
-        var result = context.cached(type, type.toInstance());
+        var result = context.cached(type, instanceFactory.instantiate(type));
 
         stream(type.asClass().getDeclaredFields())
                 .filter(x -> !customizationContext.getIgnoredFields().contains(x.getName()))

--- a/src/main/java/com/github/nylle/javafixture/specimen/InterfaceSpecimen.java
+++ b/src/main/java/com/github/nylle/javafixture/specimen/InterfaceSpecimen.java
@@ -3,7 +3,7 @@ package com.github.nylle.javafixture.specimen;
 import com.github.nylle.javafixture.Context;
 import com.github.nylle.javafixture.CustomizationContext;
 import com.github.nylle.javafixture.ISpecimen;
-import com.github.nylle.javafixture.ProxyFactory;
+import com.github.nylle.javafixture.InstanceFactory;
 import com.github.nylle.javafixture.SpecimenFactory;
 import com.github.nylle.javafixture.SpecimenType;
 
@@ -13,7 +13,7 @@ public class InterfaceSpecimen<T> implements ISpecimen<T> {
 
     private final SpecimenType<T> type;
     private final Context context;
-    private final SpecimenFactory specimenFactory;
+    private final InstanceFactory instanceFactory;
 
     public InterfaceSpecimen(final SpecimenType<T> type, final Context context, final SpecimenFactory specimenFactory) {
 
@@ -35,7 +35,7 @@ public class InterfaceSpecimen<T> implements ISpecimen<T> {
 
         this.type = type;
         this.context = context;
-        this.specimenFactory = specimenFactory;
+        this.instanceFactory = new InstanceFactory(specimenFactory);
     }
 
     @Override
@@ -49,7 +49,7 @@ public class InterfaceSpecimen<T> implements ISpecimen<T> {
             return (T) context.cached(type);
         }
 
-        return (T) context.cached(type, ProxyFactory.create(type, specimenFactory));
+        return (T) context.cached(type, instanceFactory.proxy(type));
     }
 }
 

--- a/src/main/java/com/github/nylle/javafixture/specimen/ObjectSpecimen.java
+++ b/src/main/java/com/github/nylle/javafixture/specimen/ObjectSpecimen.java
@@ -55,6 +55,10 @@ public class ObjectSpecimen<T> implements ISpecimen<T> {
             return (T) context.cached(type);
         }
 
+        if(customizationContext.useRandomConstructor()) {
+            return context.cached(type, instanceFactory.construct(type));
+        }
+
         var result = context.cached(type, instanceFactory.instantiate(type));
 
         Arrays.stream(type.asClass().getDeclaredFields())

--- a/src/main/java/com/github/nylle/javafixture/specimen/ObjectSpecimen.java
+++ b/src/main/java/com/github/nylle/javafixture/specimen/ObjectSpecimen.java
@@ -3,6 +3,7 @@ package com.github.nylle.javafixture.specimen;
 import com.github.nylle.javafixture.Context;
 import com.github.nylle.javafixture.CustomizationContext;
 import com.github.nylle.javafixture.ISpecimen;
+import com.github.nylle.javafixture.InstanceFactory;
 import com.github.nylle.javafixture.ReflectionHelper;
 import com.github.nylle.javafixture.SpecimenFactory;
 import com.github.nylle.javafixture.SpecimenType;
@@ -16,6 +17,7 @@ public class ObjectSpecimen<T> implements ISpecimen<T> {
     private final SpecimenType<T> type;
     private final Context context;
     private final SpecimenFactory specimenFactory;
+    private final InstanceFactory instanceFactory;
 
     public ObjectSpecimen(final SpecimenType<T> type, final Context context, final SpecimenFactory specimenFactory) {
 
@@ -38,6 +40,7 @@ public class ObjectSpecimen<T> implements ISpecimen<T> {
         this.type = type;
         this.context = context;
         this.specimenFactory = specimenFactory;
+        this.instanceFactory = new InstanceFactory(specimenFactory);
     }
 
     @Override
@@ -52,7 +55,7 @@ public class ObjectSpecimen<T> implements ISpecimen<T> {
             return (T) context.cached(type);
         }
 
-        var result = context.cached(type, type.toInstance());
+        var result = context.cached(type, instanceFactory.instantiate(type));
 
         Arrays.stream(type.asClass().getDeclaredFields())
                 .filter(field -> !customizationContext.getIgnoredFields().contains(field.getName()))

--- a/src/test/java/com/github/nylle/javafixture/FixtureTest.java
+++ b/src/test/java/com/github/nylle/javafixture/FixtureTest.java
@@ -343,7 +343,7 @@ class FixtureTest {
 
             Fixture fixture = new Fixture(configuration);
 
-            var result = fixture.createThroughRandomConstructor(TestObjectWithGenericConstructor.class);
+            var result = fixture.construct(TestObjectWithGenericConstructor.class);
 
             assertThat(result).isInstanceOf(TestObjectWithGenericConstructor.class);
             assertThat(result.getValue()).isInstanceOf(String.class);
@@ -467,7 +467,7 @@ class FixtureTest {
 
             Fixture fixture = new Fixture(configuration);
 
-            var result = fixture.createThroughRandomConstructor(new SpecimenType<TestObjectWithGenericConstructor>() {});
+            var result = fixture.construct(new SpecimenType<TestObjectWithGenericConstructor>() {});
 
             assertThat(result).isInstanceOf(TestObjectWithGenericConstructor.class);
             assertThat(result.getValue()).isInstanceOf(String.class);

--- a/src/test/java/com/github/nylle/javafixture/FixtureTest.java
+++ b/src/test/java/com/github/nylle/javafixture/FixtureTest.java
@@ -3,6 +3,7 @@ package com.github.nylle.javafixture;
 import com.github.nylle.javafixture.testobjects.ITestGeneric;
 import com.github.nylle.javafixture.testobjects.ITestGenericInside;
 import com.github.nylle.javafixture.testobjects.TestObjectGeneric;
+import com.github.nylle.javafixture.testobjects.TestObjectWithGenericConstructor;
 import com.github.nylle.javafixture.testobjects.TestObjectWithGenerics;
 import com.github.nylle.javafixture.testobjects.TestObjectWithNestedGenericInterfaces;
 import com.github.nylle.javafixture.testobjects.TestObjectWithNestedGenerics;
@@ -336,6 +337,21 @@ class FixtureTest {
             assertThat(result.getTestGeneric().getU().getTestGeneric().getU()).isInstanceOf(Integer.class);
 
         }
+
+        @Test
+        void createThroughRandomConstructor() {
+
+            Fixture fixture = new Fixture(configuration);
+
+            var result = fixture.createThroughRandomConstructor(TestObjectWithGenericConstructor.class);
+
+            assertThat(result).isInstanceOf(TestObjectWithGenericConstructor.class);
+            assertThat(result.getValue()).isInstanceOf(String.class);
+            assertThat(result.getInteger()).isInstanceOf(Optional.class);
+            assertThat(result.getInteger()).isPresent();
+            assertThat(result.getInteger().get()).isInstanceOf(Integer.class);
+            assertThat(result.getPrivateField()).isNull();
+        }
     }
 
     @Nested
@@ -445,6 +461,20 @@ class FixtureTest {
             assertThat(result.getString()).isNull();
             assertThat(result.getPrimitiveInt()).isEqualTo(0);
         }
-    }
 
+        @Test
+        void createThroughRandomConstructor() {
+
+            Fixture fixture = new Fixture(configuration);
+
+            var result = fixture.createThroughRandomConstructor(new SpecimenType<TestObjectWithGenericConstructor>() {});
+
+            assertThat(result).isInstanceOf(TestObjectWithGenericConstructor.class);
+            assertThat(result.getValue()).isInstanceOf(String.class);
+            assertThat(result.getInteger()).isInstanceOf(Optional.class);
+            assertThat(result.getInteger()).isPresent();
+            assertThat(result.getInteger().get()).isInstanceOf(Integer.class);
+            assertThat(result.getPrivateField()).isNull();
+        }
+    }
 }

--- a/src/test/java/com/github/nylle/javafixture/InstanceFactoryTest.java
+++ b/src/test/java/com/github/nylle/javafixture/InstanceFactoryTest.java
@@ -1,0 +1,49 @@
+package com.github.nylle.javafixture;
+
+import com.github.nylle.javafixture.testobjects.TestObjectWithGenericConstructor;
+import com.github.nylle.javafixture.testobjects.TestObjectWithoutDefaultConstructor;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class InstanceFactoryTest {
+
+    @Test
+    void canCreateInstanceFromConstructor() {
+
+        var sut = new InstanceFactory(new SpecimenFactory(new Context(Configuration.configure().useRandomConstructor(true))));
+
+        TestObjectWithoutDefaultConstructor result = sut.construct(SpecimenType.fromClass(TestObjectWithoutDefaultConstructor.class));
+
+        assertThat(result).isInstanceOf(TestObjectWithoutDefaultConstructor.class);
+        assertThat(result.getStrings()).isInstanceOf(List.class);
+        assertThat(result.getStrings()).isNotEmpty();
+        assertThat(result.getStrings().get(0)).isInstanceOf(String.class);
+    }
+
+    @Test
+    void optionalsAreNeverPresent() {
+
+        var sut = new InstanceFactory(new SpecimenFactory(new Context(Configuration.configure().useRandomConstructor(true))));
+
+        TestObjectWithGenericConstructor result = sut.construct(SpecimenType.fromClass(TestObjectWithGenericConstructor.class));
+
+        assertThat(result).isInstanceOf(TestObjectWithGenericConstructor.class);
+        assertThat(result.getInteger()).isInstanceOf(Optional.class);
+        assertThat(result.getInteger()).isNotPresent();
+    }
+
+    @Test
+    void fieldsNotSetByConstructorAreNull() {
+
+        var sut = new InstanceFactory(new SpecimenFactory(new Context(Configuration.configure().useRandomConstructor(true))));
+
+        TestObjectWithGenericConstructor result = sut.construct(SpecimenType.fromClass(TestObjectWithGenericConstructor.class));
+
+        assertThat(result).isInstanceOf(TestObjectWithGenericConstructor.class);
+        assertThat(result.getPrivateField()).isNull();
+    }
+}

--- a/src/test/java/com/github/nylle/javafixture/InstanceFactoryTest.java
+++ b/src/test/java/com/github/nylle/javafixture/InstanceFactoryTest.java
@@ -1,11 +1,14 @@
 package com.github.nylle.javafixture;
 
 import com.github.nylle.javafixture.testobjects.TestObjectWithGenericConstructor;
+import com.github.nylle.javafixture.testobjects.TestObjectWithPrivateConstructor;
 import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
 
+import static com.github.nylle.javafixture.SpecimenType.fromClass;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 class InstanceFactoryTest {
 
@@ -14,7 +17,7 @@ class InstanceFactoryTest {
 
         var sut = new InstanceFactory(new SpecimenFactory(new Context(Configuration.configure())));
 
-        TestObjectWithGenericConstructor result = sut.construct(SpecimenType.fromClass(TestObjectWithGenericConstructor.class));
+        TestObjectWithGenericConstructor result = sut.construct(fromClass(TestObjectWithGenericConstructor.class));
 
         assertThat(result).isInstanceOf(TestObjectWithGenericConstructor.class);
         assertThat(result.getValue()).isInstanceOf(String.class);
@@ -28,9 +31,20 @@ class InstanceFactoryTest {
 
         var sut = new InstanceFactory(new SpecimenFactory(new Context(Configuration.configure())));
 
-        TestObjectWithGenericConstructor result = sut.construct(SpecimenType.fromClass(TestObjectWithGenericConstructor.class));
+        TestObjectWithGenericConstructor result = sut.construct(fromClass(TestObjectWithGenericConstructor.class));
 
         assertThat(result).isInstanceOf(TestObjectWithGenericConstructor.class);
         assertThat(result.getPrivateField()).isNull();
+    }
+
+    @Test
+    void canOnlyUsePublicConstructor() {
+
+        var sut = new InstanceFactory(new SpecimenFactory(new Context(Configuration.configure())));
+
+        assertThatExceptionOfType(SpecimenException.class)
+                .isThrownBy(() -> sut.construct(fromClass(TestObjectWithPrivateConstructor.class)))
+                .withMessageContaining("no public constructor found")
+                .withNoCause();
     }
 }

--- a/src/test/java/com/github/nylle/javafixture/InstanceFactoryTest.java
+++ b/src/test/java/com/github/nylle/javafixture/InstanceFactoryTest.java
@@ -1,10 +1,8 @@
 package com.github.nylle.javafixture;
 
 import com.github.nylle.javafixture.testobjects.TestObjectWithGenericConstructor;
-import com.github.nylle.javafixture.testobjects.TestObjectWithoutDefaultConstructor;
 import org.junit.jupiter.api.Test;
 
-import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -14,32 +12,21 @@ class InstanceFactoryTest {
     @Test
     void canCreateInstanceFromConstructor() {
 
-        var sut = new InstanceFactory(new SpecimenFactory(new Context(Configuration.configure().useRandomConstructor(true))));
-
-        TestObjectWithoutDefaultConstructor result = sut.construct(SpecimenType.fromClass(TestObjectWithoutDefaultConstructor.class));
-
-        assertThat(result).isInstanceOf(TestObjectWithoutDefaultConstructor.class);
-        assertThat(result.getStrings()).isInstanceOf(List.class);
-        assertThat(result.getStrings()).isNotEmpty();
-        assertThat(result.getStrings().get(0)).isInstanceOf(String.class);
-    }
-
-    @Test
-    void optionalsAreNeverPresent() {
-
-        var sut = new InstanceFactory(new SpecimenFactory(new Context(Configuration.configure().useRandomConstructor(true))));
+        var sut = new InstanceFactory(new SpecimenFactory(new Context(Configuration.configure())));
 
         TestObjectWithGenericConstructor result = sut.construct(SpecimenType.fromClass(TestObjectWithGenericConstructor.class));
 
         assertThat(result).isInstanceOf(TestObjectWithGenericConstructor.class);
+        assertThat(result.getValue()).isInstanceOf(String.class);
         assertThat(result.getInteger()).isInstanceOf(Optional.class);
-        assertThat(result.getInteger()).isNotPresent();
+        assertThat(result.getInteger()).isPresent();
+        assertThat(result.getInteger().get()).isInstanceOf(Integer.class);
     }
 
     @Test
     void fieldsNotSetByConstructorAreNull() {
 
-        var sut = new InstanceFactory(new SpecimenFactory(new Context(Configuration.configure().useRandomConstructor(true))));
+        var sut = new InstanceFactory(new SpecimenFactory(new Context(Configuration.configure())));
 
         TestObjectWithGenericConstructor result = sut.construct(SpecimenType.fromClass(TestObjectWithGenericConstructor.class));
 

--- a/src/test/java/com/github/nylle/javafixture/testobjects/TestObjectWithGenericConstructor.java
+++ b/src/test/java/com/github/nylle/javafixture/testobjects/TestObjectWithGenericConstructor.java
@@ -1,0 +1,28 @@
+package com.github.nylle.javafixture.testobjects;
+
+import java.util.Optional;
+
+public class TestObjectWithGenericConstructor {
+    private final String privateField = null;
+
+    private final String value;
+
+    private final Optional<Integer> integer;
+
+    public TestObjectWithGenericConstructor(String value, Optional<Integer> integer) {
+        this.value = value;
+        this.integer = integer;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public Optional<Integer> getInteger() {
+        return integer;
+    }
+
+    public String getPrivateField() {
+        return privateField;
+    }
+}

--- a/src/test/java/com/github/nylle/javafixture/testobjects/TestObjectWithPrivateConstructor.java
+++ b/src/test/java/com/github/nylle/javafixture/testobjects/TestObjectWithPrivateConstructor.java
@@ -1,0 +1,14 @@
+package com.github.nylle.javafixture.testobjects;
+
+public class TestObjectWithPrivateConstructor {
+
+    private final String value;
+
+    private TestObjectWithPrivateConstructor() {
+        this.value = null;
+    }
+
+    protected TestObjectWithPrivateConstructor(String value) {
+        this.value = value;
+    }
+}

--- a/src/test/java/com/github/nylle/javafixture/testobjects/TestObjectWithoutDefaultConstructor.java
+++ b/src/test/java/com/github/nylle/javafixture/testobjects/TestObjectWithoutDefaultConstructor.java
@@ -9,4 +9,8 @@ public class TestObjectWithoutDefaultConstructor {
     public TestObjectWithoutDefaultConstructor(List<String> strings) {
         this.strings = strings;
     }
+
+    public List<String> getStrings() {
+        return strings;
+    }
 }


### PR DESCRIPTION
This will alow the user to create a new instance by using a random constructor, if one is available. If not, the object will be created "empty" meaning the fields will not be filled and thus be either null
or default-value.

It is important to keep in mind, that objects created this way cannot be customized any further.