### PR TITLE
JAVAFIXTURE-26: Allow configuration setting for numbers to be positive-only 

### DIFF
--- a/src/main/java/com/github/nylle/javafixture/Configuration.java
+++ b/src/main/java/com/github/nylle/javafixture/Configuration.java
@@ -9,6 +9,7 @@ public class Configuration {
     private int maxCollectionSize = 10;
     private int minCollectionSize = 2;
     private int streamSize = 3;
+    private boolean usePositiveNumbersOnly = false;
 
     private Clock clock = Clock.fixed(Instant.now(), ZoneOffset.UTC);
 
@@ -18,6 +19,7 @@ public class Configuration {
      * <li>maxCollectionSize = 10
      * <li>minCollectionSize = 2
      * <li>streamSize = 3
+     * <li>usePositiveNumbersOnly = false
      * <li>clock = Clock.fixed(Instant.now(), ZoneOffset.UTC)
      * </ul><p>
      */
@@ -31,10 +33,26 @@ public class Configuration {
      * @param minCollectionSize the minimum size of arrays, collections and maps
      * @param streamSize the exact size of the result stream when creating many objects at once
      */
-    public Configuration(int maxCollectionSize, int minCollectionSize, int streamSize) {
+    public Configuration(final int maxCollectionSize, final int minCollectionSize, final int streamSize) {
         this.maxCollectionSize = maxCollectionSize;
         this.minCollectionSize = minCollectionSize;
         this.streamSize = streamSize;
+        this.usePositiveNumbersOnly = false;
+    }
+
+    /**
+     * Creates a new configuration with the specified values
+     *
+     * @param maxCollectionSize the maximum size of arrays, collections and maps
+     * @param minCollectionSize the minimum size of arrays, collections and maps
+     * @param streamSize the exact size of the result stream when creating many objects at once
+     * @param usePositiveNumbersOnly whether to generate only positive numbers including 0
+     */
+    public Configuration(final int maxCollectionSize, final int minCollectionSize, final int streamSize, final boolean usePositiveNumbersOnly) {
+        this.maxCollectionSize = maxCollectionSize;
+        this.minCollectionSize = minCollectionSize;
+        this.streamSize = streamSize;
+        this.usePositiveNumbersOnly = usePositiveNumbersOnly;
     }
 
     /**
@@ -73,11 +91,19 @@ public class Configuration {
     }
 
     /**
+     * @return whether to generate only positive numbers including 0
+     */
+    public boolean usePositiveNumbersOnly() {
+        return this.usePositiveNumbersOnly;
+    }
+
+    /**
      * Creates a new default configuration with the following values
      * <p><ul>
      * <li>maxCollectionSize = 10
      * <li>minCollectionSize = 2
      * <li>streamSize = 3
+     * <li>usePositiveNumbersOnly = false
      * <li>clock = Clock.fixed(Instant.now(), ZoneOffset.UTC)
      * </ul><p>
      */
@@ -113,6 +139,15 @@ public class Configuration {
      */
     public Configuration clock(Clock clock) {
         this.clock = clock;
+        return this;
+    }
+
+    /**
+     * @param usePositiveNumbersOnly whether to generate only positive numbers including 0
+     * @return this {@code Configuration}
+     */
+    public Configuration usePositiveNumbersOnly(boolean usePositiveNumbersOnly) {
+        this.usePositiveNumbersOnly = usePositiveNumbersOnly;
         return this;
     }
 }

--- a/src/main/java/com/github/nylle/javafixture/Fixture.java
+++ b/src/main/java/com/github/nylle/javafixture/Fixture.java
@@ -15,6 +15,7 @@ public class Fixture {
      * <li>maxCollectionSize = 10
      * <li>minCollectionSize = 2
      * <li>streamSize = 3
+     * <li>usePositiveNumbersOnly = false
      * <li>clock = Clock.fixed(Instant.now(), ZoneOffset.UTC)
      * </ul><p>
      */
@@ -37,6 +38,7 @@ public class Fixture {
      * <li>maxCollectionSize = 10
      * <li>minCollectionSize = 2
      * <li>streamSize = 3
+     * <li>usePositiveNumbersOnly = false
      * <li>clock = Clock.fixed(Instant.now(), ZoneOffset.UTC)
      * </ul><p>
      */

--- a/src/main/java/com/github/nylle/javafixture/PseudoRandom.java
+++ b/src/main/java/com/github/nylle/javafixture/PseudoRandom.java
@@ -1,0 +1,56 @@
+package com.github.nylle.javafixture;
+
+import java.nio.charset.Charset;
+import java.util.Random;
+import java.util.UUID;
+
+public class PseudoRandom {
+
+    private final Random random = new Random();
+
+    public Short nextShort(boolean positiveOnly) {
+        return positiveOnly
+                ? (short) random.nextInt(1 << 15)
+                : (short) random.nextInt(1 << 16);
+    }
+
+    public Integer nextInt(boolean positiveOnly) {
+        return positiveOnly
+                ? (int) (new Random().nextFloat() * (Integer.MAX_VALUE))
+                : random.nextInt();
+    }
+
+    public Long nextLong(boolean positiveOnly) {
+        return positiveOnly
+                ? (long) (Math.random() * (Long.MAX_VALUE))
+                : random.nextLong();
+    }
+
+    public Float nextFloat(boolean positiveOnly) {
+        return positiveOnly
+                ? new Random().nextFloat() * (Float.MAX_VALUE)
+                : random.nextFloat();
+    }
+
+    public Double nextDouble(boolean positiveOnly) {
+        return positiveOnly
+                ? new Random().nextDouble() * (Double.MAX_VALUE)
+                : random.nextDouble();
+    }
+
+    public String nextString() {
+        return UUID.randomUUID().toString();
+    }
+
+    public Boolean nextBool() {
+        return random.nextBoolean();
+    }
+
+    public Character nextChar() {
+        return UUID.randomUUID().toString().charAt(0);
+    }
+
+    public Byte nextByte() {
+        return UUID.randomUUID().toString().getBytes(Charset.defaultCharset())[0];
+    }
+}

--- a/src/main/java/com/github/nylle/javafixture/SpecimenFactory.java
+++ b/src/main/java/com/github/nylle/javafixture/SpecimenFactory.java
@@ -21,7 +21,7 @@ public class SpecimenFactory {
     public <T> ISpecimen<T> build(final SpecimenType<T> type) {
 
         if (type.isPrimitive() || type.isBoxed() || type.asClass() == String.class) {
-            return new PrimitiveSpecimen<>(type);
+            return new PrimitiveSpecimen<>(type, context);
         }
 
         if (type.isEnum()) {

--- a/src/main/java/com/github/nylle/javafixture/specimen/PrimitiveSpecimen.java
+++ b/src/main/java/com/github/nylle/javafixture/specimen/PrimitiveSpecimen.java
@@ -1,22 +1,22 @@
 package com.github.nylle.javafixture.specimen;
 
+import com.github.nylle.javafixture.Configuration;
+import com.github.nylle.javafixture.Context;
 import com.github.nylle.javafixture.CustomizationContext;
 import com.github.nylle.javafixture.ISpecimen;
+import com.github.nylle.javafixture.PseudoRandom;
 import com.github.nylle.javafixture.SpecimenException;
 import com.github.nylle.javafixture.SpecimenType;
-
-import java.nio.charset.Charset;
-import java.util.Random;
-import java.util.UUID;
 
 import static com.github.nylle.javafixture.CustomizationContext.noContext;
 
 public class PrimitiveSpecimen<T> implements ISpecimen<T> {
 
     private final SpecimenType<T> type;
-    private final Random random;
+    private final PseudoRandom pseudoRandom;
+    private final Configuration configuration;
 
-    public PrimitiveSpecimen(final SpecimenType<T> type) {
+    public PrimitiveSpecimen(final SpecimenType<T> type, final Context context) {
 
         if(type == null) {
             throw new IllegalArgumentException("type: null");
@@ -27,7 +27,8 @@ public class PrimitiveSpecimen<T> implements ISpecimen<T> {
         }
 
         this.type = type;
-        this.random = new Random();
+        this.pseudoRandom = new PseudoRandom();
+        this.configuration = context.getConfiguration();
     }
 
     @Override
@@ -38,39 +39,39 @@ public class PrimitiveSpecimen<T> implements ISpecimen<T> {
     @Override
     public T create(final CustomizationContext customizationContext) {
         if (type.asClass().equals(String.class)) {
-            return (T) UUID.randomUUID().toString();
+            return (T) pseudoRandom.nextString();
         }
 
         if (type.asClass().equals(Boolean.class) || type.asClass().equals(boolean.class)) {
-            return (T) Boolean.valueOf(random.nextBoolean());
+            return (T) pseudoRandom.nextBool();
         }
 
         if (type.asClass().equals(Character.class) || type.asClass().equals(char.class)) {
-            return (T) Character.valueOf(UUID.randomUUID().toString().charAt(0));
+            return (T) pseudoRandom.nextChar();
         }
 
         if (type.asClass().equals(Byte.class) || type.asClass().equals(byte.class)) {
-            return (T) Byte.valueOf(UUID.randomUUID().toString().getBytes(Charset.defaultCharset())[0]);
+            return (T) pseudoRandom.nextByte();
         }
 
         if (type.asClass().equals(Short.class) || type.asClass().equals(short.class)) {
-            return (T) Short.valueOf((short)random.nextInt(Short.MAX_VALUE + 1));
+            return (T) pseudoRandom.nextShort(configuration.usePositiveNumbersOnly());
         }
 
         if (type.asClass().equals(Integer.class) || type.asClass().equals(int.class)) {
-            return (T) Integer.valueOf(random.nextInt());
+            return (T) pseudoRandom.nextInt(configuration.usePositiveNumbersOnly());
         }
 
         if (type.asClass().equals(Long.class) || type.asClass().equals(long.class)) {
-            return (T) Long.valueOf(random.nextLong());
+            return (T) pseudoRandom.nextLong(configuration.usePositiveNumbersOnly());
         }
 
         if (type.asClass().equals(Float.class) || type.asClass().equals(float.class)) {
-            return (T) Float.valueOf(random.nextFloat());
+            return (T) pseudoRandom.nextFloat(configuration.usePositiveNumbersOnly());
         }
 
         if (type.asClass().equals(Double.class) || type.asClass().equals(double.class)) {
-            return (T) Double.valueOf(random.nextDouble());
+            return (T) pseudoRandom.nextDouble(configuration.usePositiveNumbersOnly());
         }
 
         throw new SpecimenException("Unsupported type: "+ type);

--- a/src/test/java/com/github/nylle/javafixture/PseudoRandomTest.java
+++ b/src/test/java/com/github/nylle/javafixture/PseudoRandomTest.java
@@ -1,0 +1,65 @@
+package com.github.nylle.javafixture;
+
+import com.github.nylle.javafixture.annotations.testcases.TestCase;
+import com.github.nylle.javafixture.annotations.testcases.TestWithCases;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PseudoRandomTest {
+
+    @TestWithCases
+    @TestCase(bool1 = false, short2 = Short.MIN_VALUE, short3 = Short.MAX_VALUE)
+    @TestCase(bool1 = true, short2 = 0, short3 = Short.MAX_VALUE)
+    void nextShort(boolean onlyPositive, short min, short max) {
+        assertThat(new PseudoRandom().nextShort(onlyPositive)).isBetween(min, max);
+    }
+
+    @TestWithCases
+    @TestCase(bool1 = false, int2 = Integer.MIN_VALUE, int3 = Integer.MAX_VALUE)
+    @TestCase(bool1 = true, int2 = 0, int3 = Integer.MAX_VALUE)
+    void nextInt(boolean onlyPositive, int min, int max) {
+        assertThat(new PseudoRandom().nextInt(onlyPositive)).isBetween(min, max);
+    }
+
+    @TestWithCases
+    @TestCase(bool1 = false, long2 = Long.MIN_VALUE, long3 = Long.MAX_VALUE)
+    @TestCase(bool1 = true, long2 = 0, long3 = Long.MAX_VALUE)
+    void nextLong(boolean onlyPositive, long min, long max) {
+        assertThat(new PseudoRandom().nextLong(onlyPositive)).isBetween(min, max);
+    }
+
+    @TestWithCases
+    @TestCase(bool1 = false, float2 = Float.MIN_VALUE, float3 = Float.MAX_VALUE)
+    @TestCase(bool1 = true, float2 = 0, float3 = Float.MAX_VALUE)
+    void nextFloat(boolean onlyPositive, float min, float max) {
+        assertThat(new PseudoRandom().nextFloat(onlyPositive)).isBetween(min, max);
+    }
+
+    @TestWithCases
+    @TestCase(bool1 = false, double2 = Double.MIN_VALUE, double3 = Double.MAX_VALUE)
+    @TestCase(bool1 = true, double2 = 0, double3 = Double.MAX_VALUE)
+    void nextDouble(boolean onlyPositive, double min, double max) {
+        assertThat(new PseudoRandom().nextDouble(onlyPositive)).isBetween(min, max);
+    }
+
+    @Test
+    void nextString() {
+        assertThat(new PseudoRandom().nextString()).isNotBlank();
+    }
+
+    @Test
+    void nextBool() {
+        assertThat(new PseudoRandom().nextBool()).isIn(true, false);
+    }
+
+    @Test
+    void nextChar() {
+        assertThat(new PseudoRandom().nextChar()).isBetween(Character.MIN_VALUE, Character.MAX_VALUE);
+    }
+
+    @Test
+    void nextByte() {
+        assertThat(new PseudoRandom().nextByte()).isBetween(Byte.MIN_VALUE, Byte.MAX_VALUE);
+    }
+}

--- a/src/test/java/com/github/nylle/javafixture/specimen/PrimitiveSpecimenTest.java
+++ b/src/test/java/com/github/nylle/javafixture/specimen/PrimitiveSpecimenTest.java
@@ -1,29 +1,34 @@
 package com.github.nylle.javafixture.specimen;
 
-import com.github.nylle.javafixture.SpecimenType;
+import com.github.nylle.javafixture.Context;
+import com.github.nylle.javafixture.annotations.testcases.TestCase;
+import com.github.nylle.javafixture.annotations.testcases.TestWithCases;
 import org.junit.jupiter.api.Test;
 
+import static com.github.nylle.javafixture.Configuration.configure;
+import static com.github.nylle.javafixture.SpecimenType.fromClass;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class PrimitiveSpecimenTest {
+
     @Test
     void typeIsRequired() {
-        assertThatThrownBy(() -> new PrimitiveSpecimen<>(null))
+        assertThatThrownBy(() -> new PrimitiveSpecimen<>(null, new Context(configure())))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("type: null");
     }
 
     @Test
     void onlyPrimitiveTypes() {
-        assertThatThrownBy(() -> new PrimitiveSpecimen<>(SpecimenType.fromClass(Object.class)))
+        assertThatThrownBy(() -> new PrimitiveSpecimen<>(fromClass(Object.class), new Context(configure())))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("type: " + Object.class.getName());
     }
 
     @Test
     void createString() {
-        var sut = new PrimitiveSpecimen<String>(SpecimenType.fromClass(String.class));
+        var sut = new PrimitiveSpecimen<String>(fromClass(String.class), new Context(configure()));
 
         var actual = sut.create();
 
@@ -33,7 +38,7 @@ class PrimitiveSpecimenTest {
 
     @Test
     void createBoolean() {
-        var sut = new PrimitiveSpecimen<>(SpecimenType.fromClass(boolean.class));
+        var sut = new PrimitiveSpecimen<>(fromClass(boolean.class), new Context(configure()));
 
         var actual = sut.create();
 
@@ -43,7 +48,7 @@ class PrimitiveSpecimenTest {
 
     @Test
     void createByte() {
-        var sut = new PrimitiveSpecimen<>(SpecimenType.fromClass(byte.class));
+        var sut = new PrimitiveSpecimen<>(fromClass(byte.class), new Context(configure()));
 
         var actual = sut.create();
 
@@ -51,54 +56,63 @@ class PrimitiveSpecimenTest {
         assertThat(actual.toString().length()).isGreaterThan(0);
     }
 
-    @Test
-    void createShort() {
-        var sut = new PrimitiveSpecimen<Short>(SpecimenType.fromClass(short.class));
+    @TestWithCases
+    @TestCase(bool1 = false, short2 = Short.MIN_VALUE, short3 = Short.MAX_VALUE)
+    @TestCase(bool1 = true, short2 = 0, short3 = Short.MAX_VALUE)
+    void createShort(boolean positiveOnly, short min, short max) {
+        var sut = new PrimitiveSpecimen<Short>(fromClass(short.class), new Context(configure().usePositiveNumbersOnly(positiveOnly)));
 
         var actual = sut.create();
 
         assertThat(actual).isInstanceOf(Short.class);
-        assertThat(actual).isBetween(Short.MIN_VALUE, Short.MAX_VALUE);
+        assertThat(actual).isBetween(min, max);
     }
 
-    @Test
-    void createInteger() {
-        var sut = new PrimitiveSpecimen<Integer>(SpecimenType.fromClass(int.class));
+    @TestWithCases
+    @TestCase(bool1 = false, int2 = Integer.MIN_VALUE, int3 = Integer.MAX_VALUE)
+    @TestCase(bool1 = true, int2 = 0, int3 = Integer.MAX_VALUE)
+    void createInteger(boolean positiveOnly, int min, int max) {
+        var sut = new PrimitiveSpecimen<Integer>(fromClass(int.class), new Context(configure().usePositiveNumbersOnly(positiveOnly)));
 
         var actual = sut.create();
 
         assertThat(actual).isInstanceOf(Integer.class);
-        assertThat(actual).isBetween(Integer.MIN_VALUE, Integer.MAX_VALUE);
+        assertThat(actual).isBetween(min, max);
     }
 
-    @Test
-    void createLong() {
-        var sut = new PrimitiveSpecimen<Long>(SpecimenType.fromClass(long.class));
+    @TestWithCases
+    @TestCase(bool1 = false, long2 = Long.MIN_VALUE, long3 = Long.MAX_VALUE)
+    @TestCase(bool1 = true, long2 = 0, long3 = Long.MAX_VALUE)
+    void createLong(boolean positiveOnly, long min, long max) {
+        var sut = new PrimitiveSpecimen<Long>(fromClass(long.class), new Context(configure().usePositiveNumbersOnly(positiveOnly)));
 
         var actual = sut.create();
 
         assertThat(actual).isInstanceOf(Long.class);
-        assertThat(actual).isBetween(Long.MIN_VALUE, Long.MAX_VALUE);
+        assertThat(actual).isBetween(min, max);
     }
 
-    @Test
-    void createFloat() {
-        var sut = new PrimitiveSpecimen<Float>(SpecimenType.fromClass(float.class));
+    @TestWithCases
+    @TestCase(bool1 = false, float2 = Float.MIN_VALUE, float3 = Float.MAX_VALUE)
+    @TestCase(bool1 = true, float2 = 0, float3 = Float.MAX_VALUE)
+    void createFloat(boolean positiveOnly, float min, float max) {
+        var sut = new PrimitiveSpecimen<Float>(fromClass(float.class), new Context(configure().usePositiveNumbersOnly(positiveOnly)));
 
         var actual = sut.create();
 
         assertThat(actual).isInstanceOf(Float.class);
-        assertThat(actual).isBetween(Float.MIN_VALUE, Float.MAX_VALUE);
+        assertThat(actual).isBetween(min, max);
     }
 
-    @Test
-    void createDouble() {
-        var sut = new PrimitiveSpecimen<Double>(SpecimenType.fromClass(double.class));
+    @TestWithCases
+    @TestCase(bool1 = false, double2 = Double.MIN_VALUE, double3 = Double.MAX_VALUE)
+    @TestCase(bool1 = true, double2 = 0, double3 = Double.MAX_VALUE)
+    void createDouble(boolean positiveOnly, double min, double max) {
+        var sut = new PrimitiveSpecimen<Double>(fromClass(double.class), new Context(configure().usePositiveNumbersOnly(positiveOnly)));
 
         var actual = sut.create();
 
         assertThat(actual).isInstanceOf(Double.class);
-        assertThat(actual).isBetween(Double.MIN_VALUE, Double.MAX_VALUE);
+        assertThat(actual).isBetween(min, max);
     }
-
 }


### PR DESCRIPTION
When numbers (short, int, long, float, double) are generated, they contain any value between the maximum negative and maximum positive value for the type. This behaviour is generally favourable. However, there might be cases in which a negative value might not make much sense, e.g. for file size or length of things.