### PR TITLE
Fix an exception when using primitive wrappers in test method arguments

### DIFF
--- a/src/main/java/com/github/nylle/javafixture/annotations/testcases/ReflectedTestCase.java
+++ b/src/main/java/com/github/nylle/javafixture/annotations/testcases/ReflectedTestCase.java
@@ -12,6 +12,17 @@ import static java.util.Arrays.stream;
 
 public class ReflectedTestCase {
 
+    private static final Map<Class<?>, Class<?>> primitiveWrapperMap = Map.of(
+            Boolean.class, Boolean.TYPE,
+            Character.class, Character.TYPE,
+            Byte.class, Byte.TYPE,
+            Short.class, Short.TYPE,
+            Integer.class, Integer.TYPE,
+            Long.class, Long.TYPE,
+            Float.class, Float.TYPE,
+            Double.class, Double.TYPE
+    );
+
     private Map<Class<?>, List<?>> matrix = new HashMap<>();
 
     public ReflectedTestCase(TestCase testCase) {
@@ -22,7 +33,7 @@ public class ReflectedTestCase {
 
     @SuppressWarnings("unchecked")
     public <T> T getTestCaseValueFor(Class<T> type, int i) {
-        return (T) matrix.get(type).get(i);
+        return (T) matrix.get(primitiveWrapperMap.getOrDefault(type, type)).get(i);
     }
 
     @SuppressWarnings("unchecked")

--- a/src/test/java/com/github/nylle/javafixture/annotations/testcases/TestCaseTest.java
+++ b/src/test/java/com/github/nylle/javafixture/annotations/testcases/TestCaseTest.java
@@ -1,5 +1,8 @@
 package com.github.nylle.javafixture.annotations.testcases;
 
+import java.math.BigDecimal;
+import java.math.MathContext;
+import java.math.RoundingMode;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -8,6 +11,9 @@ import java.util.NavigableSet;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -32,4 +38,38 @@ class TestCaseTest {
         assertThat(interfaceType.isAssignableFrom(type)).isEqualTo(expected);
     }
 
+    @Nested
+    @DisplayName("verify that primitive wrapper classes are supported as method arguments")
+    class PrimitiveAutoboxing {
+
+        @TestWithCases
+        @TestCase(byte1 = 1, short2 = 2, int3 = 3, long4 = 6)
+        @TestCase(byte1 = 2, short2 = -2, int3 = 0, long4 = 0)
+        void testIntegerTypes(Byte first, Short second, Integer third, Long sum) {
+            assertThat(Long.valueOf(first + second + third)).isEqualTo(sum);
+        }
+
+        @TestWithCases
+        @TestCase(float1 = 1.5f, double2 = 1.5d)
+        @TestCase(float1 = 3.25f, double2 = 3.25d)
+        void testFloatingPointTypes(Float first, Double second) {
+            final var firstDecimal = new BigDecimal(first, new MathContext(2, RoundingMode.HALF_UP));
+            final var secondDecimal = new BigDecimal(second, new MathContext(2, RoundingMode.HALF_UP));
+            assertThat(firstDecimal).isEqualTo(secondDecimal);
+        }
+
+        @TestWithCases
+        @TestCase(char1 = '#', str2 = "#")
+        @TestCase(char1 = '$', str2 = "$")
+        void testCharacterType(Character character, String characterAsString) {
+            assertThat(character).isEqualTo(characterAsString.charAt(0));
+        }
+
+        @TestWithCases
+        @TestCase(bool1 = true, str2 = "true")
+        @TestCase(bool2 = false, str2 = "false")
+        void testBooleanType(Boolean bool, String expectedBooleanValue) {
+            assertThat(bool).isEqualTo(Boolean.parseBoolean(expectedBooleanValue));
+        }
+    }
 }


### PR DESCRIPTION
This avoids an exception, when a wrapper class (eg. Integer) is used as a test method argument, that corresponds to a primitive parameter in the @TestCase annotation.

Some insight provided by the [Apache Commons Lang](https://commons.apache.org/proper/commons-lang/) library, specifically:
https://commons.apache.org/proper/commons-lang/apidocs/src-html/org/apache/commons/lang3/ClassUtils.html#line.866