### PR TITLE
JAVAFIXTURE-41: Add support for fluent configuration

### DIFF
--- a/src/main/java/com/github/nylle/javafixture/Configuration.java
+++ b/src/main/java/com/github/nylle/javafixture/Configuration.java
@@ -150,4 +150,13 @@ public class Configuration {
         this.usePositiveNumbersOnly = usePositiveNumbersOnly;
         return this;
     }
+
+    /**
+     * Returns a new fixture with this configuration
+     *
+     * @return {@code Fixture}
+     */
+    public Fixture fixture() {
+        return new Fixture(this);
+    }
 }

--- a/src/main/java/com/github/nylle/javafixture/Fixture.java
+++ b/src/main/java/com/github/nylle/javafixture/Fixture.java
@@ -157,4 +157,20 @@ public class Fixture {
     public <T> void addManyTo(Collection<T> result, final SpecimenType<T> type) {
         result.addAll(new SpecimenBuilder<>(type, configuration).createMany().collect(Collectors.toList()));
     }
+
+    /**
+     * Returns a new default configuration with the following values
+     * <p><ul>
+     * <li>maxCollectionSize = 10
+     * <li>minCollectionSize = 2
+     * <li>streamSize = 3
+     * <li>usePositiveNumbersOnly = false
+     * <li>clock = Clock.fixed(Instant.now(), ZoneOffset.UTC)
+     * </ul><p>
+     *
+     * @return {@code Configuration}
+     */
+    public static Configuration configuration() {
+        return new Configuration();
+    }
 }

--- a/src/test/java/com/github/nylle/javafixture/ConfigurationTest.java
+++ b/src/test/java/com/github/nylle/javafixture/ConfigurationTest.java
@@ -1,0 +1,22 @@
+package com.github.nylle.javafixture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+class ConfigurationTest {
+
+    @Test
+    void canCreateAFixtureWithGivenConfiguration() {
+
+        var result = new Configuration()
+                .collectionSizeRange(1, 1)
+                .fixture()
+                .create(new SpecimenType<List<Integer>>() {});
+
+        assertThat(result).hasSize(1);
+    }
+
+}

--- a/src/test/java/com/github/nylle/javafixture/FixtureTest.java
+++ b/src/test/java/com/github/nylle/javafixture/FixtureTest.java
@@ -22,9 +22,11 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.Period;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -503,5 +505,18 @@ class FixtureTest {
             assertThat(result.getInteger().get()).isInstanceOf(Integer.class);
             assertThat(result.getPrivateField()).isNull();
         }
+    }
+
+    @Test
+    void canCreateDefaultConfiguration() {
+
+        var result = Fixture.configuration();
+
+        assertThat(result.getMaxCollectionSize()).isEqualTo(10);
+        assertThat(result.getMinCollectionSize()).isEqualTo(2);
+        assertThat(result.getStreamSize()).isEqualTo(3);
+        assertThat(result.usePositiveNumbersOnly()).isFalse();
+        assertThat(result.getClock().instant()).isBefore(Instant.now());
+        assertThat(result.getClock().getZone()).isEqualTo(ZoneOffset.UTC);
     }
 }


### PR DESCRIPTION
The static method `configuration()` on the `Fixture`-class now returns a default-`Configuration`. 
Additionally the `Configuration`-class now can create a new `Fixture` with itself as argument.