### PR TITLE
JF-54: Add syntactic sugar for Optional

### DIFF
--- a/src/main/java/com/github/nylle/javafixture/Fixture.java
+++ b/src/main/java/com/github/nylle/javafixture/Fixture.java
@@ -1,6 +1,7 @@
 package com.github.nylle.javafixture;
 
 import java.util.Collection;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -71,6 +72,17 @@ public class Fixture {
      */
     public <T> T create(final Class<T> type) {
         return new SpecimenBuilder<T>(SpecimenType.fromClass(type), configuration).create();
+    }
+
+    /**
+     * Creates a new optional of the specified type, recursively populated with random values
+     *
+     * @param type the {@code Class<T>} based on which the object is created
+     * @param <T> the type of the object to be created
+     * @return a new {@code Optional} of the specified {@code Class<T>}
+     */
+    public <T> Optional<T> createOptional(final Class<T> type) {
+        return new SpecimenBuilder<T>(SpecimenType.fromClass(type), configuration).createOptional();
     }
 
     /**

--- a/src/main/java/com/github/nylle/javafixture/ISpecimenBuilder.java
+++ b/src/main/java/com/github/nylle/javafixture/ISpecimenBuilder.java
@@ -1,10 +1,13 @@
 package com.github.nylle.javafixture;
 
+import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 
 public interface ISpecimenBuilder<T> {
     T create();
+
+    Optional<T> createOptional();
 
     Stream<T> createMany();
 

--- a/src/main/java/com/github/nylle/javafixture/SpecimenBuilder.java
+++ b/src/main/java/com/github/nylle/javafixture/SpecimenBuilder.java
@@ -4,6 +4,7 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 import java.util.stream.IntStream;
@@ -29,6 +30,14 @@ public class SpecimenBuilder<T> implements ISpecimenBuilder<T> {
     @Override
     public T create() {
         return customize(new SpecimenFactory(new Context(configuration, predefinedInstances)).build(type).create(new CustomizationContext(ignoredFields, customFields)));
+    }
+
+    /**
+     * @return a new {@code Optional<T>} based on this {@code ISpecimenBuilder<T>}
+     */
+    @Override
+    public Optional<T> createOptional() {
+        return Optional.of(create());
     }
 
     /**

--- a/src/test/java/com/github/nylle/javafixture/FixtureTest.java
+++ b/src/test/java/com/github/nylle/javafixture/FixtureTest.java
@@ -94,6 +94,17 @@ class FixtureTest {
         }
 
         @Test
+        void canCreateOptional() {
+            Fixture fixture = new Fixture(configuration);
+
+            var result = fixture.createOptional(TestPrimitive.class);
+
+            assertThat(result).isInstanceOf(Optional.class);
+            assertThat(result).isPresent();
+            assertThat(result.get()).isInstanceOf(TestPrimitive.class);
+        }
+
+        @Test
         void canCreateInstanceWithoutDefaultConstructor() {
             Fixture fixture = new Fixture(configuration);
 
@@ -197,6 +208,24 @@ class FixtureTest {
             TestPrimitive result = fixture.build(TestPrimitive.class).without("hello").create();
 
             assertThat(result.getHello()).isNull();
+        }
+
+        @Test
+        void canCustomizeOptional() {
+            Fixture fixture = new Fixture(configuration);
+
+            var result = fixture.build(TestPrimitive.class)
+                    .without("hello")
+                    .with("integer", 999)
+                    .with(x -> x.setPrimitive(888))
+                    .createOptional();
+
+            assertThat(result).isInstanceOf(Optional.class);
+            assertThat(result).isPresent();
+            assertThat(result.get()).isInstanceOf(TestPrimitive.class);
+            assertThat(result.get().getHello()).isNull();
+            assertThat(result.get().getInteger()).isEqualTo(999);
+            assertThat(result.get().getPrimitive()).isEqualTo(888);
         }
 
         @Test


### PR DESCRIPTION
This allows the creation of an Optional<T> for the desired type T.