### PR TITLE
feat: Support @Size annotation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,16 @@
             <version>3.27.0-GA</version>
         </dependency>
         <dependency>
+            <groupId>javax.validation</groupId>
+            <artifactId>validation-api</artifactId>
+            <version>2.0.1.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
+            <version>3.0.1</version>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
             <version>${junit-jupiter-engine.version}</version>

--- a/src/main/java/com/github/nylle/javafixture/ISpecimen.java
+++ b/src/main/java/com/github/nylle/javafixture/ISpecimen.java
@@ -1,10 +1,12 @@
 package com.github.nylle.javafixture;
 
+import java.lang.annotation.Annotation;
+
 public interface ISpecimen<T> {
 
-    T create();
+    T create(Annotation[] annotations);
 
-    T create(final CustomizationContext customizationContext);
+    T create(final CustomizationContext customizationContext, Annotation[] annotations);
 
 }
 

--- a/src/main/java/com/github/nylle/javafixture/InstanceFactory.java
+++ b/src/main/java/com/github/nylle/javafixture/InstanceFactory.java
@@ -6,6 +6,7 @@ import org.objenesis.instantiator.ObjectInstantiator;
 
 import javassist.util.proxy.ProxyFactory;
 
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -108,7 +109,7 @@ public class InstanceFactory {
             constructor.setAccessible(true);
             return (T) constructor.newInstance(stream(constructor.getGenericParameterTypes())
                     .map(t -> specimenFactory.build(SpecimenType.fromClass(t)))
-                    .map(s -> s.create())
+                    .map(s -> s.create(new Annotation[0]))
                     .toArray());
         } catch (Exception e) {
             throw new SpecimenException(format("Unable to construct class %s with constructor %s: %s", type.asClass(), constructor.toString(), e.getMessage()), e);
@@ -129,7 +130,7 @@ public class InstanceFactory {
         try {
             return (T) method.invoke(stream(method.getGenericParameterTypes())
                     .map(t -> specimenFactory.build(SpecimenType.fromClass(t)))
-                    .map(s -> s.create())
+                    .map(s -> s.create(new Annotation[0]))
                     .toArray());
         } catch (Exception ex) {
             return null;

--- a/src/main/java/com/github/nylle/javafixture/ProxyInvocationHandler.java
+++ b/src/main/java/com/github/nylle/javafixture/ProxyInvocationHandler.java
@@ -2,6 +2,7 @@ package com.github.nylle.javafixture;
 
 import javassist.util.proxy.MethodHandler;
 
+import java.lang.annotation.Annotation;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
@@ -30,7 +31,7 @@ public class ProxyInvocationHandler implements InvocationHandler, MethodHandler 
 
         return methodResults.computeIfAbsent(
                 method.toString(),
-                key -> specimens.getOrDefault(method.getGenericReturnType().getTypeName(), resolveSpecimen(method)).create());
+                key -> specimens.getOrDefault(method.getGenericReturnType().getTypeName(), resolveSpecimen(method)).create(new Annotation[0]));
     }
 
     @Override
@@ -41,7 +42,7 @@ public class ProxyInvocationHandler implements InvocationHandler, MethodHandler 
 
         return methodResults.computeIfAbsent(
                 thisMethod.toString(),
-                key -> specimens.getOrDefault(thisMethod.getGenericReturnType().getTypeName(), resolveSpecimen(thisMethod)).create());
+                key -> specimens.getOrDefault(thisMethod.getGenericReturnType().getTypeName(), resolveSpecimen(thisMethod)).create(new Annotation[0]));
     }
 
     private ISpecimen<?> resolveSpecimen(final Method method) {
@@ -59,7 +60,7 @@ public class ProxyInvocationHandler implements InvocationHandler, MethodHandler 
 
     private Type resolveType(Type type) {
         if (specimens.containsKey(type.getTypeName())) {
-            return specimens.get(type.getTypeName()).create().getClass();
+            return specimens.get(type.getTypeName()).create(new Annotation[0]).getClass();
         }
 
         return type;

--- a/src/main/java/com/github/nylle/javafixture/PseudoRandom.java
+++ b/src/main/java/com/github/nylle/javafixture/PseudoRandom.java
@@ -1,12 +1,17 @@
 package com.github.nylle.javafixture;
 
+import com.github.nylle.javafixture.specimen.constraints.StringConstraints;
+
 import java.nio.charset.Charset;
 import java.util.Random;
 import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class PseudoRandom {
 
     private final Random random = new Random();
+    private static final char[] letters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890".toCharArray();
 
     public Short nextShort(boolean positiveOnly) {
         return positiveOnly
@@ -38,8 +43,20 @@ public class PseudoRandom {
                 : random.nextDouble();
     }
 
-    public String nextString() {
-        return UUID.randomUUID().toString();
+    public String nextString(StringConstraints constraints) {
+        validate(constraints.getMin(), constraints.getMax());
+        return Stream.generate(() -> "" + letters[random.nextInt(letters.length)])
+                .limit(constraints.getMin() + Math.min(128, random.nextInt(constraints.getMax() - constraints.getMin())))
+                .collect(Collectors.joining());
+    }
+
+    private void validate(int min, int max) {
+        if (min < 0) {
+            throw new SpecimenException("minimum must be non-negative");
+        }
+        if (max < min) {
+            throw new SpecimenException("maximum must be greater than or equal minimum");
+        }
     }
 
     public Boolean nextBool() {

--- a/src/main/java/com/github/nylle/javafixture/SpecimenBuilder.java
+++ b/src/main/java/com/github/nylle/javafixture/SpecimenBuilder.java
@@ -1,5 +1,6 @@
 package com.github.nylle.javafixture;
 
+import java.lang.annotation.Annotation;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -29,7 +30,7 @@ public class SpecimenBuilder<T> implements ISpecimenBuilder<T> {
      */
     @Override
     public T create() {
-        return customize(new SpecimenFactory(new Context(configuration, predefinedInstances)).build(type).create(new CustomizationContext(ignoredFields, customFields)));
+        return customize(new SpecimenFactory(new Context(configuration, predefinedInstances)).build(type).create(new CustomizationContext(ignoredFields, customFields), new Annotation[0]));
     }
 
     /**
@@ -126,7 +127,7 @@ public class SpecimenBuilder<T> implements ISpecimenBuilder<T> {
     }
 
     T construct() {
-        return new SpecimenFactory(new Context(configuration)).build(type).create(new CustomizationContext(true));
+        return new SpecimenFactory(new Context(configuration)).build(type).create(new CustomizationContext(true), new Annotation[0]);
     }
 
     private T customize(T instance) {

--- a/src/main/java/com/github/nylle/javafixture/specimen/AbstractSpecimen.java
+++ b/src/main/java/com/github/nylle/javafixture/specimen/AbstractSpecimen.java
@@ -8,6 +8,8 @@ import com.github.nylle.javafixture.SpecimenException;
 import com.github.nylle.javafixture.SpecimenFactory;
 import com.github.nylle.javafixture.SpecimenType;
 
+import java.lang.annotation.Annotation;
+
 import static com.github.nylle.javafixture.CustomizationContext.noContext;
 
 public class AbstractSpecimen<T> implements ISpecimen<T> {
@@ -40,12 +42,12 @@ public class AbstractSpecimen<T> implements ISpecimen<T> {
     }
 
     @Override
-    public T create() {
-        return create(noContext());
+    public T create(Annotation[] annotations) {
+        return create(noContext(), annotations);
     }
 
     @Override
-    public T create(final CustomizationContext customizationContext) {
+    public T create(final CustomizationContext customizationContext, Annotation[] annotations) {
         if (context.isCached(type)) {
             return context.cached(type);
         }

--- a/src/main/java/com/github/nylle/javafixture/specimen/ArraySpecimen.java
+++ b/src/main/java/com/github/nylle/javafixture/specimen/ArraySpecimen.java
@@ -6,6 +6,7 @@ import com.github.nylle.javafixture.ISpecimen;
 import com.github.nylle.javafixture.SpecimenFactory;
 import com.github.nylle.javafixture.SpecimenType;
 
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Array;
 import java.util.stream.IntStream;
 
@@ -39,12 +40,12 @@ public class ArraySpecimen<T> implements ISpecimen<T> {
     }
 
     @Override
-    public T create() {
-        return create(noContext());
+    public T create(Annotation[] annotations) {
+        return create(noContext(), annotations);
     }
 
     @Override
-    public T create(final CustomizationContext customizationContext) {
+    public T create(final CustomizationContext customizationContext, Annotation[] annotations) {
         if (context.isCached(type)) {
             return context.cached(type);
         }
@@ -53,7 +54,7 @@ public class ArraySpecimen<T> implements ISpecimen<T> {
 
         T result = (T) context.cached(type, Array.newInstance(type.getComponentType(), length));
 
-        IntStream.range(0, length).boxed().forEach(i -> Array.set(result, i, specimenFactory.build(SpecimenType.fromClass(type.getComponentType())).create()));
+        IntStream.range(0, length).boxed().forEach(i -> Array.set(result, i, specimenFactory.build(SpecimenType.fromClass(type.getComponentType())).create(new Annotation[0])));
 
         return result;
     }

--- a/src/main/java/com/github/nylle/javafixture/specimen/CollectionSpecimen.java
+++ b/src/main/java/com/github/nylle/javafixture/specimen/CollectionSpecimen.java
@@ -7,6 +7,7 @@ import com.github.nylle.javafixture.InstanceFactory;
 import com.github.nylle.javafixture.SpecimenFactory;
 import com.github.nylle.javafixture.SpecimenType;
 
+import java.lang.annotation.Annotation;
 import java.util.Collection;
 import java.util.EnumSet;
 import java.util.List;
@@ -49,12 +50,12 @@ public class CollectionSpecimen<T, G> implements ISpecimen<T> {
     }
 
     @Override
-    public T create() {
-        return create(noContext());
+    public T create(Annotation[] annotations) {
+        return create(noContext(), annotations);
     }
 
     @Override
-    public T create(final CustomizationContext customizationContext) {
+    public T create(final CustomizationContext customizationContext, Annotation[] annotations) {
         if (context.isCached(type)) {
             return context.cached(type);
         }
@@ -68,7 +69,7 @@ public class CollectionSpecimen<T, G> implements ISpecimen<T> {
         IntStream.range(0, context.getConfiguration().getRandomCollectionSize())
                 .boxed()
                 .filter(x -> specimen != null)
-                .forEach(x -> collection.add(specimen.create()));
+                .forEach(x -> collection.add(specimen.create(new Annotation[0])));
 
         return (T) collection;
     }
@@ -77,7 +78,7 @@ public class CollectionSpecimen<T, G> implements ISpecimen<T> {
         final List<G> elements = IntStream.range(0, context.getConfiguration().getRandomCollectionSize())
                 .boxed()
                 .filter(x -> specimen != null)
-                .map(x -> (G) specimen.create())
+                .map(x -> (G) specimen.create(new Annotation[0]))
                 .collect(toList());
 
         return (T) EnumSet.of(elements.get(0), (G[]) elements.stream().skip(1).toArray(size -> new Enum[size]));

--- a/src/main/java/com/github/nylle/javafixture/specimen/EnumSpecimen.java
+++ b/src/main/java/com/github/nylle/javafixture/specimen/EnumSpecimen.java
@@ -5,6 +5,7 @@ import com.github.nylle.javafixture.CustomizationContext;
 import com.github.nylle.javafixture.ISpecimen;
 import com.github.nylle.javafixture.SpecimenType;
 
+import java.lang.annotation.Annotation;
 import java.util.Random;
 
 import static com.github.nylle.javafixture.CustomizationContext.noContext;
@@ -35,12 +36,12 @@ public class EnumSpecimen<T> implements ISpecimen<T> {
     }
 
     @Override
-    public T create() {
-        return create(noContext());
+    public T create(Annotation[] annotations) {
+        return create(noContext(), annotations);
     }
 
     @Override
-    public T create(CustomizationContext customizationContext) {
+    public T create(CustomizationContext customizationContext, Annotation[] annotations) {
         return context.preDefined(type, type.getEnumConstants()[random.nextInt(type.getEnumConstants().length)]);
     }
 }

--- a/src/main/java/com/github/nylle/javafixture/specimen/InterfaceSpecimen.java
+++ b/src/main/java/com/github/nylle/javafixture/specimen/InterfaceSpecimen.java
@@ -7,6 +7,8 @@ import com.github.nylle.javafixture.InstanceFactory;
 import com.github.nylle.javafixture.SpecimenFactory;
 import com.github.nylle.javafixture.SpecimenType;
 
+import java.lang.annotation.Annotation;
+
 import static com.github.nylle.javafixture.CustomizationContext.noContext;
 
 public class InterfaceSpecimen<T> implements ISpecimen<T> {
@@ -39,12 +41,12 @@ public class InterfaceSpecimen<T> implements ISpecimen<T> {
     }
 
     @Override
-    public T create() {
-        return create(noContext());
+    public T create(Annotation[] annotations) {
+        return create(noContext(), annotations);
     }
 
     @Override
-    public T create(final CustomizationContext customizationContext) {
+    public T create(final CustomizationContext customizationContext, Annotation[] annotations) {
         if (context.isCached(type)) {
             return context.cached(type);
         }

--- a/src/main/java/com/github/nylle/javafixture/specimen/MapSpecimen.java
+++ b/src/main/java/com/github/nylle/javafixture/specimen/MapSpecimen.java
@@ -7,6 +7,7 @@ import com.github.nylle.javafixture.SpecimenException;
 import com.github.nylle.javafixture.SpecimenFactory;
 import com.github.nylle.javafixture.SpecimenType;
 
+import java.lang.annotation.Annotation;
 import java.lang.reflect.InvocationTargetException;
 import java.util.EnumMap;
 import java.util.HashMap;
@@ -56,12 +57,12 @@ public class MapSpecimen<T, K, V> implements ISpecimen<T> {
     }
 
     @Override
-    public T create() {
-        return create(noContext());
+    public T create(Annotation[] annotations) {
+        return create(noContext(), annotations);
     }
 
     @Override
-    public T create(final CustomizationContext customizationContext) {
+    public T create(final CustomizationContext customizationContext, Annotation[] annotations) {
         if (context.isCached(type)) {
             return context.cached(type);
         }
@@ -71,7 +72,7 @@ public class MapSpecimen<T, K, V> implements ISpecimen<T> {
         IntStream.range(0, context.getConfiguration().getRandomCollectionSize())
                 .boxed()
                 .filter(x -> keySpecimen != null && valueSpecimen != null)
-                .forEach(x -> map.put(keySpecimen.create(), valueSpecimen.create()));
+                .forEach(x -> map.put(keySpecimen.create(new Annotation[0]), valueSpecimen.create(new Annotation[0])));
 
         return (T) map;
     }

--- a/src/main/java/com/github/nylle/javafixture/specimen/TimeSpecimen.java
+++ b/src/main/java/com/github/nylle/javafixture/specimen/TimeSpecimen.java
@@ -6,6 +6,7 @@ import com.github.nylle.javafixture.ISpecimen;
 import com.github.nylle.javafixture.SpecimenException;
 import com.github.nylle.javafixture.SpecimenType;
 
+import java.lang.annotation.Annotation;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.time.Clock;
@@ -46,12 +47,12 @@ public class TimeSpecimen<T> implements ISpecimen<T> {
     }
 
     @Override
-    public T create() {
-        return create(noContext());
+    public T create(Annotation[] annotations) {
+        return create(noContext(), annotations);
     }
 
     @Override
-    public T create(final CustomizationContext customizationContext) {
+    public T create(final CustomizationContext customizationContext, Annotation[] annotations) {
         if (Temporal.class.isAssignableFrom(type.asClass())) {
             try {
                 Method now = type.asClass().getMethod("now", Clock.class);

--- a/src/main/java/com/github/nylle/javafixture/specimen/constraints/StringConstraints.java
+++ b/src/main/java/com/github/nylle/javafixture/specimen/constraints/StringConstraints.java
@@ -1,0 +1,22 @@
+package com.github.nylle.javafixture.specimen.constraints;
+
+
+public class StringConstraints {
+
+    private final int min;
+    private final int max;
+
+    public StringConstraints(int min, int max) {
+        this.min = min;
+        this.max = max;
+    }
+
+    public int getMin() {
+        return min;
+    }
+
+    public int getMax() {
+        return max;
+    }
+
+}

--- a/src/test/java/com/github/nylle/javafixture/FixtureWithValidationTest.java
+++ b/src/test/java/com/github/nylle/javafixture/FixtureWithValidationTest.java
@@ -1,0 +1,28 @@
+package com.github.nylle.javafixture;
+
+import com.github.nylle.javafixture.testobjects.TestObjectWithJakartaValidationAnnotations;
+import com.github.nylle.javafixture.testobjects.TestObjectWithJavaxValidationAnnotations;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class FixtureWithValidationTest {
+
+    @Test
+    void javaxSizeAnnotationIsSupported() {
+        var sut = new Fixture().create(TestObjectWithJavaxValidationAnnotations.class);
+
+        assertThat(sut.getWithMinAnnotation().length()).isGreaterThanOrEqualTo(5);
+        assertThat(sut.getWithMaxAnnotation().length()).isLessThanOrEqualTo(100);
+        assertThat(sut.getWithMinMaxAnnotation().length()).isBetween(3,6);
+    }
+
+    @Test
+    void jakartaSizeAnnotationIsSupported() {
+        var sut = new Fixture().create(TestObjectWithJakartaValidationAnnotations.class);
+
+        assertThat(sut.getWithMinAnnotation().length()).isGreaterThanOrEqualTo(5);
+        assertThat(sut.getWithMaxAnnotation().length()).isLessThanOrEqualTo(100);
+        assertThat(sut.getWithMinMaxAnnotation().length()).isBetween(3,6);
+    }
+}

--- a/src/test/java/com/github/nylle/javafixture/PseudoRandomTest.java
+++ b/src/test/java/com/github/nylle/javafixture/PseudoRandomTest.java
@@ -2,9 +2,12 @@ package com.github.nylle.javafixture;
 
 import com.github.nylle.javafixture.annotations.testcases.TestCase;
 import com.github.nylle.javafixture.annotations.testcases.TestWithCases;
+import com.github.nylle.javafixture.specimen.constraints.StringConstraints;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class PseudoRandomTest {
 
@@ -43,9 +46,27 @@ class PseudoRandomTest {
         assertThat(new PseudoRandom().nextDouble(onlyPositive)).isBetween(min, max);
     }
 
-    @Test
-    void nextString() {
-        assertThat(new PseudoRandom().nextString()).isNotBlank();
+    @TestWithCases
+    @TestCase(int1 = 0, int2 = Integer.MAX_VALUE, int3 = 128)
+    @TestCase(int1 = 37, int2 = 52, int3 = 52)
+    @TestCase(int1 = 0, int2 = 4, int3 = 4)
+    @TestCase(int1 = 1024, int2 = Integer.MAX_VALUE, int3 = 1024+128)
+    @TestCase(int1 = 1025, int2 = Integer.MAX_VALUE, int3 = 1025+128)
+    @DisplayName("nextString will return a random string with at least min and at most min+128 (or max, whichever is less) characters")
+    void nextString(int min, int max, int expectedMaxLen ) {
+        var sut = new PseudoRandom();
+        var constraints = new StringConstraints(min, max);
+        assertThat(sut.nextString(constraints)).isNotBlank();
+        assertThat(sut.nextString(constraints).length()).isBetween(min, expectedMaxLen);
+    }
+
+    @TestWithCases
+    @TestCase(int1 = -3, int2 = 2)
+    @TestCase(int1 = 2, int2 = 1)
+    @DisplayName("next string will throw exception when called with values that would produce negative length string")
+    void nextStringWithIllegalValues(int min, int max) {
+        assertThatThrownBy(() -> new PseudoRandom().nextString(new StringConstraints(min,max))).isInstanceOf(SpecimenException.class);
+        assertThatThrownBy(() -> new PseudoRandom().nextString(new StringConstraints(min, max))).isInstanceOf(SpecimenException.class);
     }
 
     @Test

--- a/src/test/java/com/github/nylle/javafixture/ReflectorTest.java
+++ b/src/test/java/com/github/nylle/javafixture/ReflectorTest.java
@@ -1,9 +1,6 @@
 package com.github.nylle.javafixture;
 
-import com.github.nylle.javafixture.specimen.PrimitiveSpecimen;
-import com.github.nylle.javafixture.testobjects.inheritance.Child;
 import com.github.nylle.javafixture.testobjects.inheritance.GenericChild;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -11,116 +8,10 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 import java.util.Map;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 class ReflectorTest {
-    private SpecimenFactory specimenFactory;
-    private Context context;
-
-    @BeforeEach
-    void setup() {
-        context = new Context(new Configuration(2, 2, 3));
-        specimenFactory = new SpecimenFactory(context);
-    }
-
-    @Nested
-    @DisplayName("when populating a normal instance")
-    class PopulateNormalInstance {
-
-        @Test
-        @DisplayName("all fields are random")
-        void allFieldsArePopulated() {
-
-            var sut = new Reflector<>(new Child(), specimenFactory);
-
-            var actual = sut.populate(new CustomizationContext(List.of(), Map.of()));
-
-            assertThat(actual.getChildField()).isNotNull();
-            assertThat(actual.getParentField()).isNotNull();
-            assertThat(actual.getBaseField()).isNotNull();
-            assertThat(actual.getFieldIn3ClassesChild()).isNotNull();
-            assertThat(actual.getFieldIn3ClassesParent()).isNotNull();
-            assertThat(actual.getFieldIn3ClassesBase()).isNotNull();
-            assertThat(actual.getFieldIn2ClassesParent()).isNotNull();
-            assertThat(actual.getFieldIn2ClassesBase()).isNotNull();
-        }
-
-        @Test
-        @DisplayName("fields across all superclasses can be customised")
-        void subClassFieldsAreCustomizable() {
-
-            var sut = new Reflector<>(new Child(), specimenFactory);
-
-            Map<String, Object> customization = Map.of(
-                    "childField", "foo",
-                    "parentField", "bar",
-                    "baseField", "baz");
-
-            var actual = sut.populate(new CustomizationContext(List.of(), customization));
-
-            assertThat(actual.getChildField()).isEqualTo("foo");
-            assertThat(actual.getParentField()).isEqualTo("bar");
-            assertThat(actual.getBaseField()).isEqualTo("baz");
-            assertThat(actual.getFieldIn3ClassesChild()).isNotNull();
-            assertThat(actual.getFieldIn3ClassesParent()).isNotNull();
-            assertThat(actual.getFieldIn3ClassesBase()).isNotNull();
-            assertThat(actual.getFieldIn2ClassesParent()).isNotNull();
-            assertThat(actual.getFieldIn2ClassesBase()).isNotNull();
-        }
-
-    }
-
-    @Nested
-    @DisplayName("when populating a generic instance")
-    class PopulateGenericInstance {
-
-        @Test
-        @DisplayName("all fields are random")
-        void allFieldsArePopulated() {
-
-            var sut = new Reflector<>(new GenericChild<String>(), specimenFactory);
-
-            Map<String, ISpecimen<?>> specimen = Map.of("T", new PrimitiveSpecimen<String>(SpecimenType.fromClass(String.class), context));
-
-            var actual = sut.populate(new CustomizationContext(List.of(), Map.of()), specimen);
-
-            assertThat(actual.getChildField()).isNotNull();
-            assertThat(actual.getParentField()).isNotNull();
-            assertThat(actual.getBaseField()).isNotNull();
-            assertThat(actual.getFieldIn3ClassesChild()).isNotNull();
-            assertThat(actual.getFieldIn3ClassesParent()).isNotNull();
-            assertThat(actual.getFieldIn3ClassesBase()).isNotNull();
-            assertThat(actual.getFieldIn2ClassesParent()).isNotNull();
-            assertThat(actual.getFieldIn2ClassesBase()).isNotNull();
-        }
-
-        @Test
-        @DisplayName("fields across all superclasses can be customised")
-        void subClassFieldsAreCustomizable() {
-
-            var sut = new Reflector<>(new GenericChild<String>(), specimenFactory);
-
-            Map<String, ISpecimen<?>> specimen = Map.of("T", new PrimitiveSpecimen<String>(SpecimenType.fromClass(String.class), context));
-
-            Map<String, Object> customization = Map.of(
-                    "childField", "foo",
-                    "parentField", "bar",
-                    "baseField", "baz");
-
-            var actual = sut.populate(new CustomizationContext(List.of(), customization), specimen);
-
-            assertThat(actual.getChildField()).isEqualTo("foo");
-            assertThat(actual.getParentField()).isEqualTo("bar");
-            assertThat(actual.getBaseField()).isEqualTo("baz");
-            assertThat(actual.getFieldIn3ClassesChild()).isNotNull();
-            assertThat(actual.getFieldIn3ClassesParent()).isNotNull();
-            assertThat(actual.getFieldIn3ClassesBase()).isNotNull();
-            assertThat(actual.getFieldIn2ClassesParent()).isNotNull();
-            assertThat(actual.getFieldIn2ClassesBase()).isNotNull();
-        }
-    }
 
     @Nested
     @DisplayName("when validating a customisation")
@@ -130,7 +21,7 @@ class ReflectorTest {
         @DisplayName("with existing fields, nothing happens")
         void validCustomization() {
 
-            var sut = new Reflector<>(new GenericChild<String>(), specimenFactory);
+            var sut = new Reflector<>(new GenericChild<String>());
 
             var validCustomisation = new CustomizationContext(List.of(), Map.of("baseField", "foo"));
 
@@ -142,7 +33,7 @@ class ReflectorTest {
         @DisplayName("with any missing fields, an exception is thrown")
         void invalidCustomization() {
 
-            var sut = new Reflector<>(new GenericChild<String>(), specimenFactory);
+            var sut = new Reflector<>(new GenericChild<String>());
 
             var invalidCustomisation = new CustomizationContext(List.of(), Map.of("nonExistingField", "foo"));
 
@@ -156,7 +47,7 @@ class ReflectorTest {
         @DisplayName("to set duplicate fields, an exception is thrown")
         void customizingDuplicateFields() {
 
-            var sut = new Reflector<>(new GenericChild<String>(), specimenFactory);
+            var sut = new Reflector<>(new GenericChild<String>());
 
             Map<String, Object> customization = Map.of("fieldIn2Classes", 100.0);
 
@@ -174,7 +65,7 @@ class ReflectorTest {
         @DisplayName("to omit duplicate fields, an exception is thrown")
         void omittingDuplicateFields() {
 
-            var sut = new Reflector<>(new GenericChild<String>(), specimenFactory);
+            var sut = new Reflector<>(new GenericChild<String>());
 
             var omitting = List.of("fieldIn2Classes");
 

--- a/src/test/java/com/github/nylle/javafixture/specimen/AbstractSpecimenTest.java
+++ b/src/test/java/com/github/nylle/javafixture/specimen/AbstractSpecimenTest.java
@@ -9,6 +9,7 @@ import com.github.nylle.javafixture.testobjects.TestInterface;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.lang.annotation.Annotation;
 import java.nio.charset.Charset;
 import java.util.Map;
 
@@ -58,7 +59,7 @@ class AbstractSpecimenTest {
     void createAbstractClass() {
         var sut = new AbstractSpecimen<TestAbstractClass>(SpecimenType.fromClass(TestAbstractClass.class), context, specimenFactory);
 
-        var actual = sut.create();
+        var actual = sut.create(new Annotation[0]);
 
         assertThat(actual).isInstanceOf(TestAbstractClass.class);
         assertThat(actual.getString()).isNotBlank();
@@ -69,7 +70,7 @@ class AbstractSpecimenTest {
     void createAbstractClassWithoutConstructor() {
         var sut = new AbstractSpecimen<Charset>(SpecimenType.fromClass(Charset.class), context, specimenFactory);
 
-        var actual = sut.create();
+        var actual = sut.create(new Annotation[0]);
 
         assertThat(actual).isInstanceOf(Charset.class);
     }
@@ -77,8 +78,8 @@ class AbstractSpecimenTest {
     @Test
     void resultIsCached() {
 
-        var original = new AbstractSpecimen<TestAbstractClass>(SpecimenType.fromClass(TestAbstractClass.class), context, specimenFactory).create();
-        var cached = new AbstractSpecimen<TestAbstractClass>(SpecimenType.fromClass(TestAbstractClass.class), context, specimenFactory).create();
+        var original = new AbstractSpecimen<TestAbstractClass>(SpecimenType.fromClass(TestAbstractClass.class), context, specimenFactory).create(new Annotation[0]);
+        var cached = new AbstractSpecimen<TestAbstractClass>(SpecimenType.fromClass(TestAbstractClass.class), context, specimenFactory).create(new Annotation[0]);
 
         assertThat(original).isInstanceOf(TestAbstractClass.class);
         assertThat(original).isSameAs(cached);

--- a/src/test/java/com/github/nylle/javafixture/specimen/ArraySpecimenTest.java
+++ b/src/test/java/com/github/nylle/javafixture/specimen/ArraySpecimenTest.java
@@ -8,6 +8,7 @@ import com.github.nylle.javafixture.testobjects.example.AccountManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.lang.annotation.Annotation;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -56,7 +57,7 @@ class ArraySpecimenTest {
     void createPrimitiveArray() {
         var sut = new ArraySpecimen<int[]>(SpecimenType.fromClass(int[].class), context, specimenFactory);
 
-        var actual = sut.create();
+        var actual = sut.create(new Annotation[0]);
 
         assertThat(actual).isInstanceOf(int[].class);
         assertThat(actual.length).isEqualTo(2);
@@ -66,7 +67,7 @@ class ArraySpecimenTest {
     void createObjectArray() {
         var sut = new ArraySpecimen<Object[]>(SpecimenType.fromClass(Object[].class), context, specimenFactory);
 
-        var actual = sut.create();
+        var actual = sut.create(new Annotation[0]);
 
         assertThat(actual).isInstanceOf(Object[].class);
         assertThat(actual.length).isEqualTo(2);
@@ -76,7 +77,7 @@ class ArraySpecimenTest {
     void canHandleCircularReferences() {
         var sut = new ArraySpecimen<AccountManager[]>(SpecimenType.fromClass(AccountManager[].class), context, specimenFactory);
 
-        var actual = sut.create();
+        var actual = sut.create(new Annotation[0]);
 
         assertThat(actual).isInstanceOf(AccountManager[].class);
         assertThat(actual.length).isEqualTo(2);

--- a/src/test/java/com/github/nylle/javafixture/specimen/CollectionSpecimenTest.java
+++ b/src/test/java/com/github/nylle/javafixture/specimen/CollectionSpecimenTest.java
@@ -9,6 +9,7 @@ import com.github.nylle.javafixture.testobjects.TestObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.lang.annotation.Annotation;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -76,7 +77,7 @@ class CollectionSpecimenTest {
     void nonParameterizedCollectionIsEmpty() {
         var sut = new CollectionSpecimen<>(new SpecimenType<Collection>(){}, context, specimenFactory);
 
-        var actual = sut.create();
+        var actual = sut.create(new Annotation[0]);
 
         assertThat(actual).isInstanceOf(ArrayList.class);
         assertThat(actual.size()).isEqualTo(0);
@@ -86,7 +87,7 @@ class CollectionSpecimenTest {
     void createArrayListFromCollectionInterface() {
         var sut = new CollectionSpecimen<>(new SpecimenType<Collection<String>>(){}, context, specimenFactory);
 
-        var actual = sut.create();
+        var actual = sut.create(new Annotation[0]);
 
         assertThat(actual).isInstanceOf(ArrayList.class);
         assertThat(actual.stream().allMatch(x -> x.getClass().equals(String.class))).isTrue();
@@ -97,7 +98,7 @@ class CollectionSpecimenTest {
     void createArrayListFromListInterface() {
         var sut = new CollectionSpecimen<>(new SpecimenType<List<String>>(){}, context, specimenFactory);
 
-        var actual = sut.create();
+        var actual = sut.create(new Annotation[0]);
 
         assertThat(actual).isInstanceOf(ArrayList.class);
         assertThat(actual.stream().allMatch(x -> x.getClass().equals(String.class))).isTrue();
@@ -108,7 +109,7 @@ class CollectionSpecimenTest {
     void createTreeSetFromNavigableSetInterface() {
         var sut = new CollectionSpecimen<>(new SpecimenType<NavigableSet<String>>(){}, context, specimenFactory);
 
-        var actual = sut.create();
+        var actual = sut.create(new Annotation[0]);
 
         assertThat(actual).isInstanceOf(TreeSet.class);
         assertThat(actual.stream().allMatch(x -> x.getClass().equals(String.class))).isTrue();
@@ -119,7 +120,7 @@ class CollectionSpecimenTest {
     void createTreeSetFromSortedSetInterface() {
         var sut = new CollectionSpecimen<>(new SpecimenType<SortedSet<String>>(){}, context, specimenFactory);
 
-        var actual = sut.create();
+        var actual = sut.create(new Annotation[0]);
 
         assertThat(actual).isInstanceOf(TreeSet.class);
         assertThat(actual.stream().allMatch(x -> x.getClass().equals(String.class))).isTrue();
@@ -130,7 +131,7 @@ class CollectionSpecimenTest {
     void createHashSetFromSetInterface() {
         var sut = new CollectionSpecimen<>(new SpecimenType<Set<String>>(){}, context, specimenFactory);
 
-        var actual = sut.create();
+        var actual = sut.create(new Annotation[0]);
 
         assertThat(actual).isInstanceOf(HashSet.class);
         assertThat(actual.stream().allMatch(x -> x.getClass().equals(String.class))).isTrue();
@@ -141,7 +142,7 @@ class CollectionSpecimenTest {
     void createLinkedBlockingDequeFromBlockingDequeInterface() {
         var sut = new CollectionSpecimen<>(new SpecimenType<BlockingDeque<String>>(){}, context, specimenFactory);
 
-        var actual = sut.create();
+        var actual = sut.create(new Annotation[0]);
 
         assertThat(actual).isInstanceOf(LinkedBlockingDeque.class);
         assertThat(actual.stream().allMatch(x -> x.getClass().equals(String.class))).isTrue();
@@ -152,7 +153,7 @@ class CollectionSpecimenTest {
     void createArrayDequeFromDequeInterface() {
         var sut = new CollectionSpecimen<>(new SpecimenType<Deque<String>>(){}, context, specimenFactory);
 
-        var actual = sut.create();
+        var actual = sut.create(new Annotation[0]);
 
         assertThat(actual).isInstanceOf(ArrayDeque.class);
         assertThat(actual.stream().allMatch(x -> x.getClass().equals(String.class))).isTrue();
@@ -163,7 +164,7 @@ class CollectionSpecimenTest {
     void createLinkedTransferQueueFromTransferQueueInterface() {
         var sut = new CollectionSpecimen<>(new SpecimenType<TransferQueue<String>>(){}, context, specimenFactory);
 
-        var actual = sut.create();
+        var actual = sut.create(new Annotation[0]);
 
         assertThat(actual).isInstanceOf(LinkedTransferQueue.class);
         assertThat(actual.stream().allMatch(x -> x.getClass().equals(String.class))).isTrue();
@@ -174,7 +175,7 @@ class CollectionSpecimenTest {
     void createLinkedBlockingQueueFromBlockingQueueInterface() {
         var sut = new CollectionSpecimen<>(new SpecimenType<BlockingQueue<String>>(){}, context, specimenFactory);
 
-        var actual = sut.create();
+        var actual = sut.create(new Annotation[0]);
 
         assertThat(actual).isInstanceOf(LinkedBlockingQueue.class);
         assertThat(actual.stream().allMatch(x -> x.getClass().equals(String.class))).isTrue();
@@ -185,7 +186,7 @@ class CollectionSpecimenTest {
     void createLinkedListFromQueueInterface() {
         var sut = new CollectionSpecimen<>(new SpecimenType<Queue<String>>(){}, context, specimenFactory);
 
-        var actual = sut.create();
+        var actual = sut.create(new Annotation[0]);
 
         assertThat(actual).isInstanceOf(LinkedList.class);
         assertThat(actual.stream().allMatch(x -> x.getClass().equals(String.class))).isTrue();
@@ -196,7 +197,7 @@ class CollectionSpecimenTest {
     void createArrayList() {
         var sut = new CollectionSpecimen<>(new SpecimenType<ArrayList<String>>(){}, context, specimenFactory);
 
-        var actual = sut.create();
+        var actual = sut.create(new Annotation[0]);
 
         assertThat(actual).isInstanceOf(ArrayList.class);
         assertThat(actual.stream().allMatch(x -> x.getClass().equals(String.class))).isTrue();
@@ -207,7 +208,7 @@ class CollectionSpecimenTest {
     void createTreeSet() {
         var sut = new CollectionSpecimen<>(new SpecimenType<TreeSet<String>>(){}, context, specimenFactory);
 
-        var actual = sut.create();
+        var actual = sut.create(new Annotation[0]);
 
         assertThat(actual).isInstanceOf(TreeSet.class);
         assertThat(actual.stream().allMatch(x -> x.getClass().equals(String.class))).isTrue();
@@ -218,7 +219,7 @@ class CollectionSpecimenTest {
     void createHashSet() {
         var sut = new CollectionSpecimen<>(new SpecimenType<HashSet<String>>(){}, context, specimenFactory);
 
-        var actual = sut.create();
+        var actual = sut.create(new Annotation[0]);
 
         assertThat(actual).isInstanceOf(HashSet.class);
         assertThat(actual.stream().allMatch(x -> x.getClass().equals(String.class))).isTrue();
@@ -229,7 +230,7 @@ class CollectionSpecimenTest {
     void createEnumSet() {
         var sut = new CollectionSpecimen<>(new SpecimenType<EnumSet<TestEnum>>(){}, context, specimenFactory);
 
-        var actual = sut.create();
+        var actual = sut.create(new Annotation[0]);
 
         assertThat(actual).isNotEmpty();
         assertThat(actual.iterator().next()).isInstanceOf(TestEnum.class);
@@ -239,7 +240,7 @@ class CollectionSpecimenTest {
     void createLinkedBlockingDeque() {
         var sut = new CollectionSpecimen<>(new SpecimenType<LinkedBlockingDeque<String>>(){}, context, specimenFactory);
 
-        var actual = sut.create();
+        var actual = sut.create(new Annotation[0]);
 
         assertThat(actual).isInstanceOf(LinkedBlockingDeque.class);
         assertThat(actual.stream().allMatch(x -> x.getClass().equals(String.class))).isTrue();
@@ -250,7 +251,7 @@ class CollectionSpecimenTest {
     void createArrayDeque() {
         var sut = new CollectionSpecimen<>(new SpecimenType<ArrayDeque<String>>(){}, context, specimenFactory);
 
-        var actual = sut.create();
+        var actual = sut.create(new Annotation[0]);
 
         assertThat(actual).isInstanceOf(ArrayDeque.class);
         assertThat(actual.stream().allMatch(x -> x.getClass().equals(String.class))).isTrue();
@@ -261,7 +262,7 @@ class CollectionSpecimenTest {
     void createLinkedTransferQueue() {
         var sut = new CollectionSpecimen<>(new SpecimenType<LinkedTransferQueue<String>>(){}, context, specimenFactory);
 
-        var actual = sut.create();
+        var actual = sut.create(new Annotation[0]);
 
         assertThat(actual).isInstanceOf(LinkedTransferQueue.class);
         assertThat(actual.stream().allMatch(x -> x.getClass().equals(String.class))).isTrue();
@@ -272,7 +273,7 @@ class CollectionSpecimenTest {
     void createLinkedBlockingQueue() {
         var sut = new CollectionSpecimen<>(new SpecimenType<LinkedBlockingQueue<String>>(){}, context, specimenFactory);
 
-        var actual = sut.create();
+        var actual = sut.create(new Annotation[0]);
 
         assertThat(actual).isInstanceOf(LinkedBlockingQueue.class);
         assertThat(actual.stream().allMatch(x -> x.getClass().equals(String.class))).isTrue();
@@ -283,7 +284,7 @@ class CollectionSpecimenTest {
     void createLinkedList() {
         var sut = new CollectionSpecimen<>(new SpecimenType<LinkedList<String>>(){}, context, specimenFactory);
 
-        var actual = sut.create();
+        var actual = sut.create(new Annotation[0]);
 
         assertThat(actual).isInstanceOf(LinkedList.class);
         assertThat(actual.stream().allMatch(x -> x.getClass().equals(String.class))).isTrue();
@@ -293,8 +294,8 @@ class CollectionSpecimenTest {
     @Test
     void resultIsCached() {
 
-        var original = new CollectionSpecimen<>(new SpecimenType<List<String>>(){}, context, specimenFactory).create();
-        var cached = new CollectionSpecimen<>(new SpecimenType<List<String>>(){}, context, specimenFactory).create();
+        var original = new CollectionSpecimen<>(new SpecimenType<List<String>>(){}, context, specimenFactory).create(new Annotation[0]);
+        var cached = new CollectionSpecimen<>(new SpecimenType<List<String>>(){}, context, specimenFactory).create(new Annotation[0]);
 
         assertThat(original).isInstanceOf(List.class);
         assertThat(original.size()).isEqualTo(2);
@@ -307,7 +308,7 @@ class CollectionSpecimenTest {
     void nestedLists() {
         var sut = new CollectionSpecimen<>(new SpecimenType<List<List<String>>>(){}, context, specimenFactory);
 
-        var actual = sut.create();
+        var actual = sut.create(new Annotation[0]);
 
         assertThat(actual).isExactlyInstanceOf(ArrayList.class);
         assertThat(actual.size()).isEqualTo(2);
@@ -323,7 +324,7 @@ class CollectionSpecimenTest {
 
         var sut = new CollectionSpecimen<>(new SpecimenType<List<TestObject>>(){}, context, specimenFactory);
 
-        var actual = sut.create();
+        var actual = sut.create(new Annotation[0]);
 
         assertThat(actual).isExactlyInstanceOf(ArrayList.class);
         assertThat(actual.size()).isEqualTo(2);

--- a/src/test/java/com/github/nylle/javafixture/specimen/EnumSpecimenTest.java
+++ b/src/test/java/com/github/nylle/javafixture/specimen/EnumSpecimenTest.java
@@ -6,6 +6,7 @@ import com.github.nylle.javafixture.SpecimenType;
 import com.github.nylle.javafixture.testobjects.TestEnum;
 import org.junit.jupiter.api.Test;
 
+import java.lang.annotation.Annotation;
 import java.util.Map;
 
 import static com.github.nylle.javafixture.Configuration.configure;
@@ -40,7 +41,7 @@ class EnumSpecimenTest {
     void createEnum() {
         var sut = new EnumSpecimen<>(SpecimenType.fromClass(TestEnum.class), new Context(configure()));
 
-        var actual = sut.create();
+        var actual = sut.create(new Annotation[0]);
 
         assertThat(actual).isInstanceOf(TestEnum.class);
         assertThat(actual.toString()).isIn("VALUE1", "VALUE2", "VALUE3");
@@ -54,7 +55,7 @@ class EnumSpecimenTest {
 
         var sut = new EnumSpecimen<>(SpecimenType.fromClass(TestEnum.class), context);
 
-        var actual = sut.create();
+        var actual = sut.create(new Annotation[0]);
 
         assertThat(actual).isSameAs(expected);
     }

--- a/src/test/java/com/github/nylle/javafixture/specimen/GenericSpecimenTest.java
+++ b/src/test/java/com/github/nylle/javafixture/specimen/GenericSpecimenTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import java.lang.annotation.Annotation;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -79,7 +80,7 @@ class GenericSpecimenTest {
     void createClass() {
         var sut = new GenericSpecimen<>(new SpecimenType<Class<String>>(){}, context, specimenFactory);
 
-        var actual = sut.create();
+        var actual = sut.create(new Annotation[0]);
 
         assertThat(actual).isInstanceOf(Class.class);
         assertThat(actual).isEqualTo(String.class);
@@ -89,7 +90,7 @@ class GenericSpecimenTest {
     void createGeneric() {
         var sut = new GenericSpecimen<>(new SpecimenType<TestObjectGeneric<String, Integer>>(){}, context, specimenFactory);
 
-        var actual = sut.create();
+        var actual = sut.create(new Annotation[0]);
 
         assertThat(actual).isInstanceOf(TestObjectGeneric.class);
         assertThat(actual.getT()).isInstanceOf(String.class);
@@ -99,7 +100,7 @@ class GenericSpecimenTest {
 
     @Test
     void subSpecimenAreProperlyCached() {
-        var result = new GenericSpecimen<>(new SpecimenType<TestObjectGeneric<Optional<String>, Optional<Integer>>>(){}, context, specimenFactory).create();
+        var result = new GenericSpecimen<>(new SpecimenType<TestObjectGeneric<Optional<String>, Optional<Integer>>>(){}, context, specimenFactory).create(new Annotation[0]);
 
         assertThat(result.getT().get()).isInstanceOf(String.class);
         assertThat(result.getU().get()).isInstanceOf(Integer.class);
@@ -112,7 +113,7 @@ class GenericSpecimenTest {
         var customizationContext = new CustomizationContext(List.of(), Map.of("nonExistingField", "foo"));
 
         assertThatExceptionOfType(Exception.class)
-                .isThrownBy(() -> sut.create(customizationContext))
+                .isThrownBy(() -> sut.create(customizationContext, new Annotation[0]))
                 .withMessage("Cannot customize field 'nonExistingField': Field not found in class 'com.github.nylle.javafixture.testobjects.TestObjectGeneric<java.lang.String, java.lang.Integer>'.")
                 .withNoCause();
     }
@@ -124,7 +125,7 @@ class GenericSpecimenTest {
         var customizationContext = new CustomizationContext(List.of("nonExistingField"), Map.of());
 
         assertThatExceptionOfType(Exception.class)
-                .isThrownBy(() -> sut.create(customizationContext))
+                .isThrownBy(() -> sut.create(customizationContext, new Annotation[0]))
                 .withMessage("Cannot customize field 'nonExistingField': Field not found in class 'com.github.nylle.javafixture.testobjects.TestObjectGeneric<java.lang.String, java.lang.Integer>'.")
                 .withNoCause();
     }
@@ -138,7 +139,7 @@ class GenericSpecimenTest {
         void allFieldsArePopulated() {
             var sut = new GenericSpecimen<>(new SpecimenType<GenericChild<String>>() {}, context, specimenFactory);
 
-            var actual = sut.create();
+            var actual = sut.create(new Annotation[0]);
 
             assertThat(actual.getChildField()).isNotNull();
             assertThat(actual.getParentField()).isNotNull();
@@ -160,7 +161,7 @@ class GenericSpecimenTest {
                     "parentField", "bar",
                     "baseField", "baz");
 
-            var actual = sut.create(new CustomizationContext(List.of(), customization));
+            var actual = sut.create(new CustomizationContext(List.of(), customization), new Annotation[0]);
 
             assertThat(actual.getChildField()).isEqualTo("foo");
             assertThat(actual.getParentField()).isEqualTo("bar");
@@ -182,7 +183,7 @@ class GenericSpecimenTest {
                     "fieldIn2Classes", 100.0);
 
             assertThatExceptionOfType(SpecimenException.class)
-                    .isThrownBy(() -> sut.create(new CustomizationContext(List.of(), customization)));
+                    .isThrownBy(() -> sut.create(new CustomizationContext(List.of(), customization), new Annotation[0]));
         }
 
         @Test
@@ -195,7 +196,7 @@ class GenericSpecimenTest {
                     "fieldIn2Classes");
 
             assertThatExceptionOfType(SpecimenException.class)
-                    .isThrownBy(() -> sut.create(new CustomizationContext(omitting, Map.of())));
+                    .isThrownBy(() -> sut.create(new CustomizationContext(omitting, Map.of()), new Annotation[0]));
         }
     }
 }

--- a/src/test/java/com/github/nylle/javafixture/specimen/InterfaceSpecimenTest.java
+++ b/src/test/java/com/github/nylle/javafixture/specimen/InterfaceSpecimenTest.java
@@ -9,6 +9,7 @@ import com.github.nylle.javafixture.testobjects.TestObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.lang.annotation.Annotation;
 import java.nio.charset.Charset;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -57,7 +58,7 @@ class InterfaceSpecimenTest {
     void createInterface() {
         var sut = new InterfaceSpecimen<TestInterface>(SpecimenType.fromClass(TestInterface.class), context, specimenFactory);
 
-        var actual = sut.create();
+        var actual = sut.create(new Annotation[0]);
 
         assertThat(actual).isInstanceOf(TestInterface.class);
         assertThat(actual.publicField).isInstanceOf(Integer.class);
@@ -70,8 +71,8 @@ class InterfaceSpecimenTest {
     @Test
     void resultIsCached() {
 
-        var original = new InterfaceSpecimen<TestInterface>(SpecimenType.fromClass(TestInterface.class), context, specimenFactory).create();
-        var cached = new InterfaceSpecimen<TestInterface>(SpecimenType.fromClass(TestInterface.class), context, specimenFactory).create();
+        var original = new InterfaceSpecimen<TestInterface>(SpecimenType.fromClass(TestInterface.class), context, specimenFactory).create(new Annotation[0]);
+        var cached = new InterfaceSpecimen<TestInterface>(SpecimenType.fromClass(TestInterface.class), context, specimenFactory).create(new Annotation[0]);
 
         assertThat(original).isInstanceOf(TestInterface.class);
         assertThat(original).isSameAs(cached);

--- a/src/test/java/com/github/nylle/javafixture/specimen/MapSpecimenTest.java
+++ b/src/test/java/com/github/nylle/javafixture/specimen/MapSpecimenTest.java
@@ -9,6 +9,7 @@ import com.github.nylle.javafixture.testobjects.TestObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.lang.annotation.Annotation;
 import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.List;
@@ -64,7 +65,7 @@ class MapSpecimenTest {
 
     @Test
     void nonParameterizedMapIsEmpty() {
-        var actual = new MapSpecimen<>(new SpecimenType<Map>(){}, context, specimenFactory).create();
+        var actual = new MapSpecimen<>(new SpecimenType<Map>(){}, context, specimenFactory).create(new Annotation[0]);
 
         assertThat(actual).isInstanceOf(HashMap.class);
         assertThat(actual.size()).isEqualTo(0);
@@ -72,7 +73,7 @@ class MapSpecimenTest {
 
     @Test
     void createHashMapFromMapInterface() {
-        var actual = new MapSpecimen<>(new SpecimenType<Map<String, Integer>>(){}, context, specimenFactory).create();
+        var actual = new MapSpecimen<>(new SpecimenType<Map<String, Integer>>(){}, context, specimenFactory).create(new Annotation[0]);
 
         assertThat(actual).isInstanceOf(HashMap.class);
         assertThat(actual.size()).isEqualTo(2);
@@ -83,7 +84,7 @@ class MapSpecimenTest {
 
     @Test
     void createConcurrentSkipListMapFromConcurrentNavigableMapInterface() {
-        var actual = new MapSpecimen<>(new SpecimenType<ConcurrentNavigableMap<String, Integer>>(){}, context, specimenFactory).create();
+        var actual = new MapSpecimen<>(new SpecimenType<ConcurrentNavigableMap<String, Integer>>(){}, context, specimenFactory).create(new Annotation[0]);
 
         assertThat(actual).isInstanceOf(ConcurrentSkipListMap.class);
         assertThat(actual.size()).isEqualTo(2);
@@ -94,7 +95,7 @@ class MapSpecimenTest {
 
     @Test
     void createConcurrentHashMapFromConcurrentMapInterface() {
-        var actual = new MapSpecimen<>(new SpecimenType<ConcurrentMap<String, Integer>>(){}, context, specimenFactory).create();
+        var actual = new MapSpecimen<>(new SpecimenType<ConcurrentMap<String, Integer>>(){}, context, specimenFactory).create(new Annotation[0]);
 
         assertThat(actual).isInstanceOf(ConcurrentHashMap.class);
         assertThat(actual.size()).isEqualTo(2);
@@ -105,7 +106,7 @@ class MapSpecimenTest {
 
     @Test
     void createTreeMapFromNavigableMapInterface() {
-        var actual = new MapSpecimen<>(new SpecimenType<NavigableMap<String, Integer>>(){}, context, specimenFactory).create();
+        var actual = new MapSpecimen<>(new SpecimenType<NavigableMap<String, Integer>>(){}, context, specimenFactory).create(new Annotation[0]);
 
         assertThat(actual).isInstanceOf(TreeMap.class);
         assertThat(actual.size()).isEqualTo(2);
@@ -116,7 +117,7 @@ class MapSpecimenTest {
 
     @Test
     void createTreeMapFromSortedMapInterface() {
-        var actual = new MapSpecimen<>(new SpecimenType<SortedMap<String, Integer>>(){}, context, specimenFactory).create();
+        var actual = new MapSpecimen<>(new SpecimenType<SortedMap<String, Integer>>(){}, context, specimenFactory).create(new Annotation[0]);
 
         assertThat(actual).isInstanceOf(TreeMap.class);
         assertThat(actual.size()).isEqualTo(2);
@@ -127,7 +128,7 @@ class MapSpecimenTest {
 
     @Test
     void createHashMap() {
-        var actual = new MapSpecimen<>(new SpecimenType<HashMap<String, Integer>>(){}, context, specimenFactory).create();
+        var actual = new MapSpecimen<>(new SpecimenType<HashMap<String, Integer>>(){}, context, specimenFactory).create(new Annotation[0]);
 
         assertThat(actual).isInstanceOf(HashMap.class);
         assertThat(actual.size()).isEqualTo(2);
@@ -138,7 +139,7 @@ class MapSpecimenTest {
 
     @Test
     void createConcurrentSkipListMap() {
-        var actual = new MapSpecimen<>(new SpecimenType<ConcurrentSkipListMap<String, Integer>>(){}, context, specimenFactory).create();
+        var actual = new MapSpecimen<>(new SpecimenType<ConcurrentSkipListMap<String, Integer>>(){}, context, specimenFactory).create(new Annotation[0]);
 
         assertThat(actual).isInstanceOf(ConcurrentSkipListMap.class);
         assertThat(actual.size()).isEqualTo(2);
@@ -149,7 +150,7 @@ class MapSpecimenTest {
 
     @Test
     void createConcurrentHashMap() {
-        var actual = new MapSpecimen<>(new SpecimenType<ConcurrentHashMap<String, Integer>>(){}, context, specimenFactory).create();
+        var actual = new MapSpecimen<>(new SpecimenType<ConcurrentHashMap<String, Integer>>(){}, context, specimenFactory).create(new Annotation[0]);
 
         assertThat(actual).isInstanceOf(ConcurrentHashMap.class);
         assertThat(actual.size()).isEqualTo(2);
@@ -160,7 +161,7 @@ class MapSpecimenTest {
 
     @Test
     void createTreeMap() {
-        var actual = new MapSpecimen<>(new SpecimenType<TreeMap<String, Integer>>(){}, context, specimenFactory).create();
+        var actual = new MapSpecimen<>(new SpecimenType<TreeMap<String, Integer>>(){}, context, specimenFactory).create(new Annotation[0]);
 
         assertThat(actual).isInstanceOf(TreeMap.class);
         assertThat(actual.size()).isEqualTo(2);
@@ -171,7 +172,7 @@ class MapSpecimenTest {
 
     @Test
     void createEnumMap() {
-        var actual = new MapSpecimen<>(new SpecimenType<EnumMap<TestEnum, Integer>>(){}, context, specimenFactory).create();
+        var actual = new MapSpecimen<>(new SpecimenType<EnumMap<TestEnum, Integer>>(){}, context, specimenFactory).create(new Annotation[0]);
 
         assertThat(actual).isInstanceOf(EnumMap.class);
         assertThat(actual).isNotEmpty();
@@ -183,8 +184,8 @@ class MapSpecimenTest {
     @Test
     void resultIsCached() {
 
-        var original = new MapSpecimen<>(new SpecimenType<Map<String, Integer>>(){}, context, specimenFactory).create();
-        var cached = new MapSpecimen<>(new SpecimenType<Map<String, Integer>>(){}, context, specimenFactory).create();
+        var original = new MapSpecimen<>(new SpecimenType<Map<String, Integer>>(){}, context, specimenFactory).create(new Annotation[0]);
+        var cached = new MapSpecimen<>(new SpecimenType<Map<String, Integer>>(){}, context, specimenFactory).create(new Annotation[0]);
 
         assertThat(original).isInstanceOf(Map.class);
         assertThat(original.size()).isEqualTo(2);
@@ -197,7 +198,7 @@ class MapSpecimenTest {
     void nestedMaps() {
         var sut = new MapSpecimen<>(new SpecimenType<Map<String, Map<String, Integer>>>(){}, context, specimenFactory);
 
-        var actual = sut.create();
+        var actual = sut.create(new Annotation[0]);
 
         assertThat(actual).isExactlyInstanceOf(HashMap.class);
         assertThat(actual.size()).isEqualTo(2);
@@ -214,7 +215,7 @@ class MapSpecimenTest {
 
         var sut = new MapSpecimen<>(new SpecimenType<HashMap<String, TestObject>>(){}, context, specimenFactory);
 
-        var actual = sut.create();
+        var actual = sut.create(new Annotation[0]);
 
         assertThat(actual).isExactlyInstanceOf(HashMap.class);
         assertThat(actual.size()).isEqualTo(2);

--- a/src/test/java/com/github/nylle/javafixture/specimen/ObjectSpecimenTest.java
+++ b/src/test/java/com/github/nylle/javafixture/specimen/ObjectSpecimenTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import java.lang.annotation.Annotation;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -65,7 +66,7 @@ class ObjectSpecimenTest {
     void create() {
         var sut = new ObjectSpecimen<TestObject>(SpecimenType.fromClass(TestObject.class), context, specimenFactory);
 
-        var actual = sut.create();
+        var actual = sut.create(new Annotation[0]);
 
         assertThat(actual).isInstanceOf(TestObject.class);
         assertThat(actual.getValue()).isInstanceOf(String.class);
@@ -89,8 +90,8 @@ class ObjectSpecimenTest {
     @Test
     void resultIsCached() {
 
-        var original = new ObjectSpecimen<TestObject>(SpecimenType.fromClass(TestObject.class), context, specimenFactory).create();
-        var cached = new ObjectSpecimen<TestObject>(SpecimenType.fromClass(TestObject.class), context, specimenFactory).create();
+        var original = new ObjectSpecimen<TestObject>(SpecimenType.fromClass(TestObject.class), context, specimenFactory).create(new Annotation[0]);
+        var cached = new ObjectSpecimen<TestObject>(SpecimenType.fromClass(TestObject.class), context, specimenFactory).create(new Annotation[0]);
 
         assertThat(original).isInstanceOf(TestObject.class);
         assertThat(original).isSameAs(cached);
@@ -101,7 +102,7 @@ class ObjectSpecimenTest {
     @Test
     void ignoresStaticFields() {
 
-        var actual = new ObjectSpecimen<TestObject>(SpecimenType.fromClass(TestObject.class), context, specimenFactory).create();
+        var actual = new ObjectSpecimen<TestObject>(SpecimenType.fromClass(TestObject.class), context, specimenFactory).create(new Annotation[0]);
 
         assertThat(actual.STATIC_FIELD).isEqualTo("unchanged");
     }
@@ -113,7 +114,7 @@ class ObjectSpecimenTest {
         var customizationContext = new CustomizationContext(List.of(), Map.of("nonExistingField", "foo"));
 
         assertThatExceptionOfType(Exception.class)
-                .isThrownBy(() -> sut.create(customizationContext))
+                .isThrownBy(() -> sut.create(customizationContext, new Annotation[0]))
                 .withMessage("Cannot customize field 'nonExistingField': Field not found in class 'com.github.nylle.javafixture.testobjects.TestObject'.")
                 .withNoCause();
     }
@@ -125,7 +126,7 @@ class ObjectSpecimenTest {
         var customizationContext = new CustomizationContext(List.of("nonExistingField"), Map.of());
 
         assertThatExceptionOfType(Exception.class)
-                .isThrownBy(() -> sut.create(customizationContext))
+                .isThrownBy(() -> sut.create(customizationContext, new Annotation[0]))
                 .withMessage("Cannot customize field 'nonExistingField': Field not found in class 'com.github.nylle.javafixture.testobjects.TestObject'.")
                 .withNoCause();
     }
@@ -139,7 +140,7 @@ class ObjectSpecimenTest {
         void allFieldsArePopulated() {
             var sut = new ObjectSpecimen<Child>(SpecimenType.fromClass(Child.class), context, specimenFactory);
 
-            var actual = sut.create();
+            var actual = sut.create(new Annotation[0]);
 
             assertThat(actual.getChildField()).isNotNull();
             assertThat(actual.getParentField()).isNotNull();
@@ -161,7 +162,7 @@ class ObjectSpecimenTest {
                     "parentField", "bar",
                     "baseField", "baz");
 
-            var actual = sut.create(new CustomizationContext(List.of(), customization));
+            var actual = sut.create(new CustomizationContext(List.of(), customization), new Annotation[0]);
 
             assertThat(actual.getChildField()).isEqualTo("foo");
             assertThat(actual.getParentField()).isEqualTo("bar");
@@ -183,7 +184,7 @@ class ObjectSpecimenTest {
                     "fieldIn2Classes", 100.0);
 
             assertThatExceptionOfType(SpecimenException.class)
-                    .isThrownBy(() -> sut.create(new CustomizationContext(List.of(), customization)));
+                    .isThrownBy(() -> sut.create(new CustomizationContext(List.of(), customization), new Annotation[0]));
         }
 
         @Test
@@ -196,7 +197,7 @@ class ObjectSpecimenTest {
                     "fieldIn2Classes");
 
             assertThatExceptionOfType(SpecimenException.class)
-                    .isThrownBy(() -> sut.create(new CustomizationContext(omitting, Map.of())));
+                    .isThrownBy(() -> sut.create(new CustomizationContext(omitting, Map.of()), new Annotation[0]));
         }
     }
 }

--- a/src/test/java/com/github/nylle/javafixture/specimen/PrimitiveSpecimenTest.java
+++ b/src/test/java/com/github/nylle/javafixture/specimen/PrimitiveSpecimenTest.java
@@ -7,6 +7,7 @@ import com.github.nylle.javafixture.annotations.testcases.TestCase;
 import com.github.nylle.javafixture.annotations.testcases.TestWithCases;
 import org.junit.jupiter.api.Test;
 
+import java.lang.annotation.Annotation;
 import java.util.Map;
 
 import static com.github.nylle.javafixture.Configuration.configure;
@@ -42,7 +43,7 @@ class PrimitiveSpecimenTest {
     void createString() {
         var sut = new PrimitiveSpecimen<String>(fromClass(String.class), new Context(configure()));
 
-        var actual = sut.create();
+        var actual = sut.create(new Annotation[0]);
 
         assertThat(actual).isInstanceOf(String.class);
         assertThat(actual.length()).isGreaterThan(0);
@@ -52,7 +53,7 @@ class PrimitiveSpecimenTest {
     void createBoolean() {
         var sut = new PrimitiveSpecimen<>(fromClass(boolean.class), new Context(configure()));
 
-        var actual = sut.create();
+        var actual = sut.create(new Annotation[0]);
 
         assertThat(actual).isInstanceOf(Boolean.class);
         assertThat(actual).isIn(true, false);
@@ -62,7 +63,7 @@ class PrimitiveSpecimenTest {
     void createByte() {
         var sut = new PrimitiveSpecimen<>(fromClass(byte.class), new Context(configure()));
 
-        var actual = sut.create();
+        var actual = sut.create(new Annotation[0]);
 
         assertThat(actual).isInstanceOf(Byte.class);
         assertThat(actual.toString().length()).isGreaterThan(0);
@@ -74,7 +75,7 @@ class PrimitiveSpecimenTest {
     void createShort(boolean positiveOnly, short min, short max) {
         var sut = new PrimitiveSpecimen<Short>(fromClass(short.class), new Context(configure().usePositiveNumbersOnly(positiveOnly)));
 
-        var actual = sut.create();
+        var actual = sut.create(new Annotation[0]);
 
         assertThat(actual).isInstanceOf(Short.class);
         assertThat(actual).isBetween(min, max);
@@ -86,7 +87,7 @@ class PrimitiveSpecimenTest {
     void createInteger(boolean positiveOnly, int min, int max) {
         var sut = new PrimitiveSpecimen<Integer>(fromClass(int.class), new Context(configure().usePositiveNumbersOnly(positiveOnly)));
 
-        var actual = sut.create();
+        var actual = sut.create(new Annotation[0]);
 
         assertThat(actual).isInstanceOf(Integer.class);
         assertThat(actual).isBetween(min, max);
@@ -98,7 +99,7 @@ class PrimitiveSpecimenTest {
     void createLong(boolean positiveOnly, long min, long max) {
         var sut = new PrimitiveSpecimen<Long>(fromClass(long.class), new Context(configure().usePositiveNumbersOnly(positiveOnly)));
 
-        var actual = sut.create();
+        var actual = sut.create(new Annotation[0]);
 
         assertThat(actual).isInstanceOf(Long.class);
         assertThat(actual).isBetween(min, max);
@@ -110,7 +111,7 @@ class PrimitiveSpecimenTest {
     void createFloat(boolean positiveOnly, float min, float max) {
         var sut = new PrimitiveSpecimen<Float>(fromClass(float.class), new Context(configure().usePositiveNumbersOnly(positiveOnly)));
 
-        var actual = sut.create();
+        var actual = sut.create(new Annotation[0]);
 
         assertThat(actual).isInstanceOf(Float.class);
         assertThat(actual).isBetween(min, max);
@@ -122,7 +123,7 @@ class PrimitiveSpecimenTest {
     void createDouble(boolean positiveOnly, double min, double max) {
         var sut = new PrimitiveSpecimen<Double>(fromClass(double.class), new Context(configure().usePositiveNumbersOnly(positiveOnly)));
 
-        var actual = sut.create();
+        var actual = sut.create(new Annotation[0]);
 
         assertThat(actual).isInstanceOf(Double.class);
         assertThat(actual).isBetween(min, max);
@@ -145,7 +146,7 @@ class PrimitiveSpecimenTest {
 
         var sut = new PrimitiveSpecimen<>(SpecimenType.fromClass(type), context);
 
-        var actual = sut.create();
+        var actual = sut.create(new Annotation[0]);
 
         assertThat(actual).isSameAs(expected);
     }

--- a/src/test/java/com/github/nylle/javafixture/specimen/TimeSpecimenTest.java
+++ b/src/test/java/com/github/nylle/javafixture/specimen/TimeSpecimenTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
+import java.lang.annotation.Annotation;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
@@ -72,7 +73,7 @@ class TimeSpecimenTest {
     void createDuration(Class type) {
         var sut = new TimeSpecimen<>(SpecimenType.fromClass(type), context);
 
-        var actual = sut.create();
+        var actual = sut.create(new Annotation[0]);
 
         assertThat(actual).isInstanceOf(type);
         assertThat(actual.toString()).isNotEmpty();
@@ -80,7 +81,7 @@ class TimeSpecimenTest {
 
     @Test
     void throwsExceptionForUnknownType() {
-        assertThatThrownBy(() -> new TimeSpecimen<>(SpecimenType.fromClass(TemporalAmount.class), context).create())
+        assertThatThrownBy(() -> new TimeSpecimen<>(SpecimenType.fromClass(TemporalAmount.class), context).create(new Annotation[0]))
                 .isInstanceOf(SpecimenException.class)
                 .hasMessageContaining("Unsupported type:");
     }
@@ -110,7 +111,7 @@ class TimeSpecimenTest {
     @TestCase(class1 = java.util.Date.class)
     @DisplayName("create should return a valid object")
     void create(Class type) {
-        var sut = new TimeSpecimen<>(SpecimenType.fromClass(type), context).create();
+        var sut = new TimeSpecimen<>(SpecimenType.fromClass(type), context).create(new Annotation[0]);
         // if the object is not valid, the toString method will fail, it cannot print it
         assertThat(sut.toString()).isNotEmpty();
     }
@@ -123,7 +124,7 @@ class TimeSpecimenTest {
 
         var sut = new TimeSpecimen<>(SpecimenType.fromClass(Instant.class), context);
 
-        var actual = sut.create();
+        var actual = sut.create(new Annotation[0]);
 
         assertThat(actual).isEqualTo(Instant.MIN);
     }
@@ -157,7 +158,7 @@ class TimeSpecimenTest {
 
         var sut = new TimeSpecimen<>(SpecimenType.fromClass(type), context);
 
-        var actual = sut.create();
+        var actual = sut.create(new Annotation[0]);
 
         assertThat(actual).isSameAs(expected);
     }

--- a/src/test/java/com/github/nylle/javafixture/testobjects/TestObjectWithJakartaValidationAnnotations.java
+++ b/src/test/java/com/github/nylle/javafixture/testobjects/TestObjectWithJakartaValidationAnnotations.java
@@ -1,0 +1,26 @@
+package com.github.nylle.javafixture.testobjects;
+
+import jakarta.validation.constraints.Size;
+
+public class TestObjectWithJakartaValidationAnnotations {
+    @Size(min = 3, max = 6)
+    private String withMinMaxAnnotation;
+
+    @Size(min = 5)
+    private String withMinAnnotation;
+
+    @Size(max = 100)
+    private String withMaxAnnotation;
+
+    public String getWithMinMaxAnnotation() {
+        return withMinMaxAnnotation;
+    }
+
+    public String getWithMinAnnotation() {
+        return withMinAnnotation;
+    }
+
+    public String getWithMaxAnnotation() {
+        return withMaxAnnotation;
+    }
+}

--- a/src/test/java/com/github/nylle/javafixture/testobjects/TestObjectWithJavaxValidationAnnotations.java
+++ b/src/test/java/com/github/nylle/javafixture/testobjects/TestObjectWithJavaxValidationAnnotations.java
@@ -1,0 +1,26 @@
+package com.github.nylle.javafixture.testobjects;
+
+import javax.validation.constraints.Size;
+
+public class TestObjectWithJavaxValidationAnnotations {
+    @Size(min = 3, max = 6)
+    private String withMinMaxAnnotation;
+
+    @Size(min = 5)
+    private String withMinAnnotation;
+
+    @Size(max = 100)
+    private String withMaxAnnotation;
+
+    public String getWithMinMaxAnnotation() {
+        return withMinMaxAnnotation;
+    }
+
+    public String getWithMinAnnotation() {
+        return withMinAnnotation;
+    }
+
+    public String getWithMaxAnnotation() {
+        return withMaxAnnotation;
+    }
+}


### PR DESCRIPTION
This constraint is currently only applicable to Strings.
It will produce a random alphanumeric string with a length between min and max characters.
JAVAFIXTURE-61

In order to not produce strings too long, I limited the random string length to 1024 or (min + 128, if min is > 1024).
Because of the [transition from Jave EE to Jakarta-EE](https://blogs.oracle.com/javamagazine/post/transition-from-java-ee-to-jakarta-ee), I included both dependencies, i.e. the code will support both
```javax.annotations.constraints``` and ```jakarta.annotations.constraints```