### PR TITLE
add SpecialSpecimen to fixture File and URI

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -22,6 +22,8 @@ ij_java_layout_static_imports_separately = true
 
 ij_java_blank_lines_after_package = 1
 ij_java_blank_lines_after_imports = 1
+ij_any_keep_simple_classes_in_one_line = true
+ij_any_keep_simple_lambdas_in_one_line = true
 
 [*.json]
 indent_size = 2

--- a/src/main/java/com/github/nylle/javafixture/SpecimenFactory.java
+++ b/src/main/java/com/github/nylle/javafixture/SpecimenFactory.java
@@ -9,6 +9,7 @@ import com.github.nylle.javafixture.specimen.InterfaceSpecimen;
 import com.github.nylle.javafixture.specimen.MapSpecimen;
 import com.github.nylle.javafixture.specimen.ObjectSpecimen;
 import com.github.nylle.javafixture.specimen.PrimitiveSpecimen;
+import com.github.nylle.javafixture.specimen.SpecialSpecimen;
 import com.github.nylle.javafixture.specimen.TimeSpecimen;
 
 public class SpecimenFactory {
@@ -55,6 +56,10 @@ public class SpecimenFactory {
 
         if (type.isAbstract()) {
             return new AbstractSpecimen<>(type, context, this);
+        }
+
+        if( type.isSpecialType()) {
+            return new SpecialSpecimen<>(type, context);
         }
 
         return new ObjectSpecimen<>(type, context, this);

--- a/src/main/java/com/github/nylle/javafixture/SpecimenType.java
+++ b/src/main/java/com/github/nylle/javafixture/SpecimenType.java
@@ -161,6 +161,16 @@ public class SpecimenType<T> extends TypeCapture<T> {
         return false;
     }
 
+    public boolean isSpecialType() {
+        if (asClass().equals(java.io.File.class)) {
+            return true;
+        }
+        if (asClass().equals(java.net.URI.class)) {
+            return true;
+        }
+        return false;
+    }
+
     public boolean isPrimitive() {
         return asClass().isPrimitive();
     }

--- a/src/main/java/com/github/nylle/javafixture/specimen/SpecialSpecimen.java
+++ b/src/main/java/com/github/nylle/javafixture/specimen/SpecialSpecimen.java
@@ -1,0 +1,52 @@
+package com.github.nylle.javafixture.specimen;
+
+import com.github.nylle.javafixture.Context;
+import com.github.nylle.javafixture.CustomizationContext;
+import com.github.nylle.javafixture.ISpecimen;
+import com.github.nylle.javafixture.SpecimenType;
+
+import java.io.File;
+import java.lang.annotation.Annotation;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.UUID;
+
+public class SpecialSpecimen<T> implements ISpecimen<T> {
+    private final SpecimenType<T> type;
+    private final Context context;
+
+
+    public SpecialSpecimen(SpecimenType<T> type, Context context) {
+        if (type == null) {
+            throw new IllegalArgumentException("type: null");
+        }
+
+        if (!type.isSpecialType()) {
+            throw new IllegalArgumentException("type: " + type.getName());
+        }
+
+        if (context == null) {
+            throw new IllegalArgumentException("context: null");
+        }
+
+        this.type = type;
+        this.context = context;
+    }
+
+    @Override
+    public T create(Annotation[] annotations) {
+        return create(CustomizationContext.noContext(), annotations);
+    }
+
+    @Override
+    public T create(CustomizationContext customizationContext, Annotation[] annotations) {
+        if (type.asClass().equals(File.class)) {
+            return (T) new File(UUID.randomUUID().toString());
+        }
+        try {
+            return (T) new URI("https://localhost/" + UUID.randomUUID());
+        } catch (URISyntaxException e) {
+            return null;
+        }
+    }
+}

--- a/src/test/java/com/github/nylle/javafixture/SpecimenFactoryTest.java
+++ b/src/test/java/com/github/nylle/javafixture/SpecimenFactoryTest.java
@@ -10,12 +10,15 @@ import com.github.nylle.javafixture.specimen.InterfaceSpecimen;
 import com.github.nylle.javafixture.specimen.MapSpecimen;
 import com.github.nylle.javafixture.specimen.ObjectSpecimen;
 import com.github.nylle.javafixture.specimen.PrimitiveSpecimen;
+import com.github.nylle.javafixture.specimen.SpecialSpecimen;
 import com.github.nylle.javafixture.specimen.TimeSpecimen;
 import com.github.nylle.javafixture.testobjects.TestEnum;
 import com.github.nylle.javafixture.testobjects.TestObjectGeneric;
 import com.github.nylle.javafixture.testobjects.example.IContract;
 import org.junit.jupiter.api.Test;
 
+import java.io.File;
+import java.net.URI;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.MonthDay;
@@ -48,6 +51,8 @@ class SpecimenFactoryTest {
     @TestCase(class1 = Instant.class, class2 = TimeSpecimen.class)
     @TestCase(class1 = java.util.Date.class, class2 = TimeSpecimen.class)
     @TestCase(class1 = java.sql.Date.class, class2 = TimeSpecimen.class)
+    @TestCase(class1 = File.class, class2 = SpecialSpecimen.class)
+    @TestCase(class1 = URI.class, class2 = SpecialSpecimen.class)
     @TestCase(class1 = Object.class, class2 = ObjectSpecimen.class)
     void build(Class<?> value, Class<?> expected) {
         assertThat(new SpecimenFactory(new Context(new Configuration())).build(SpecimenType.fromClass(value))).isExactlyInstanceOf(expected);

--- a/src/test/java/com/github/nylle/javafixture/SpecimenTypeTest.java
+++ b/src/test/java/com/github/nylle/javafixture/SpecimenTypeTest.java
@@ -62,16 +62,13 @@ class SpecimenTypeTest {
 
     @Test
     void asClass() {
-        assertThat(new SpecimenType<String>() {
-        }.asClass()).isEqualTo(String.class);
+        assertThat(new SpecimenType<String>() {}.asClass()).isEqualTo(String.class);
     }
 
     @Test
     void isParametrized() {
-        assertThat(new SpecimenType<String>() {
-        }.isParameterized()).isFalse();
-        assertThat(new SpecimenType<Optional<String>>() {
-        }.isParameterized()).isTrue();
+        assertThat(new SpecimenType<String>() {}.isParameterized()).isFalse();
+        assertThat(new SpecimenType<Optional<String>>() {}.isParameterized()).isTrue();
     }
 
     @Test
@@ -91,42 +88,24 @@ class SpecimenTypeTest {
 
     @Test
     void isCollection() {
-        assertThat(new SpecimenType<Collection<String>>() {
-        }.isCollection()).isTrue();
-        assertThat(new SpecimenType<List<String>>() {
-        }.isCollection()).isTrue();
-        assertThat(new SpecimenType<NavigableSet<String>>() {
-        }.isCollection()).isTrue();
-        assertThat(new SpecimenType<SortedSet<String>>() {
-        }.isCollection()).isTrue();
-        assertThat(new SpecimenType<Set<String>>() {
-        }.isCollection()).isTrue();
-        assertThat(new SpecimenType<Deque<String>>() {
-        }.isCollection()).isTrue();
-        assertThat(new SpecimenType<BlockingDeque<String>>() {
-        }.isCollection()).isTrue();
-        assertThat(new SpecimenType<Queue<String>>() {
-        }.isCollection()).isTrue();
-        assertThat(new SpecimenType<BlockingQueue<String>>() {
-        }.isCollection()).isTrue();
-        assertThat(new SpecimenType<TransferQueue<String>>() {
-        }.isCollection()).isTrue();
-        assertThat(new SpecimenType<ArrayList<String>>() {
-        }.isCollection()).isTrue();
-        assertThat(new SpecimenType<HashSet<String>>() {
-        }.isCollection()).isTrue();
-        assertThat(new SpecimenType<TreeSet<String>>() {
-        }.isCollection()).isTrue();
-        assertThat(new SpecimenType<ArrayDeque<String>>() {
-        }.isCollection()).isTrue();
-        assertThat(new SpecimenType<LinkedBlockingDeque<String>>() {
-        }.isCollection()).isTrue();
-        assertThat(new SpecimenType<LinkedList<String>>() {
-        }.isCollection()).isTrue();
-        assertThat(new SpecimenType<LinkedBlockingQueue<String>>() {
-        }.isCollection()).isTrue();
-        assertThat(new SpecimenType<LinkedTransferQueue<String>>() {
-        }.isCollection()).isTrue();
+        assertThat(new SpecimenType<Collection<String>>() {}.isCollection()).isTrue();
+        assertThat(new SpecimenType<List<String>>() {}.isCollection()).isTrue();
+        assertThat(new SpecimenType<NavigableSet<String>>() {}.isCollection()).isTrue();
+        assertThat(new SpecimenType<SortedSet<String>>() {}.isCollection()).isTrue();
+        assertThat(new SpecimenType<Set<String>>() {}.isCollection()).isTrue();
+        assertThat(new SpecimenType<Deque<String>>() {}.isCollection()).isTrue();
+        assertThat(new SpecimenType<BlockingDeque<String>>() {}.isCollection()).isTrue();
+        assertThat(new SpecimenType<Queue<String>>() {}.isCollection()).isTrue();
+        assertThat(new SpecimenType<BlockingQueue<String>>() {}.isCollection()).isTrue();
+        assertThat(new SpecimenType<TransferQueue<String>>() {}.isCollection()).isTrue();
+        assertThat(new SpecimenType<ArrayList<String>>() {}.isCollection()).isTrue();
+        assertThat(new SpecimenType<HashSet<String>>() {}.isCollection()).isTrue();
+        assertThat(new SpecimenType<TreeSet<String>>() {}.isCollection()).isTrue();
+        assertThat(new SpecimenType<ArrayDeque<String>>() {}.isCollection()).isTrue();
+        assertThat(new SpecimenType<LinkedBlockingDeque<String>>() {}.isCollection()).isTrue();
+        assertThat(new SpecimenType<LinkedList<String>>() {}.isCollection()).isTrue();
+        assertThat(new SpecimenType<LinkedBlockingQueue<String>>() {}.isCollection()).isTrue();
+        assertThat(new SpecimenType<LinkedTransferQueue<String>>() {}.isCollection()).isTrue();
     }
 
     @TestWithCases
@@ -154,24 +133,15 @@ class SpecimenTypeTest {
 
     @Test
     void isMap() {
-        assertThat(new SpecimenType<Map>() {
-        }.isMap()).isTrue();
-        assertThat(new SpecimenType<ConcurrentNavigableMap>() {
-        }.isMap()).isTrue();
-        assertThat(new SpecimenType<ConcurrentMap>() {
-        }.isMap()).isTrue();
-        assertThat(new SpecimenType<NavigableMap>() {
-        }.isMap()).isTrue();
-        assertThat(new SpecimenType<SortedMap>() {
-        }.isMap()).isTrue();
-        assertThat(new SpecimenType<TreeMap>() {
-        }.isMap()).isTrue();
-        assertThat(new SpecimenType<ConcurrentSkipListMap>() {
-        }.isMap()).isTrue();
-        assertThat(new SpecimenType<ConcurrentHashMap>() {
-        }.isMap()).isTrue();
-        assertThat(new SpecimenType<HashMap>() {
-        }.isMap()).isTrue();
+        assertThat(new SpecimenType<Map>() {}.isMap()).isTrue();
+        assertThat(new SpecimenType<ConcurrentNavigableMap>() {}.isMap()).isTrue();
+        assertThat(new SpecimenType<ConcurrentMap>() {}.isMap()).isTrue();
+        assertThat(new SpecimenType<NavigableMap>() {}.isMap()).isTrue();
+        assertThat(new SpecimenType<SortedMap>() {}.isMap()).isTrue();
+        assertThat(new SpecimenType<TreeMap>() {}.isMap()).isTrue();
+        assertThat(new SpecimenType<ConcurrentSkipListMap>() {}.isMap()).isTrue();
+        assertThat(new SpecimenType<ConcurrentHashMap>() {}.isMap()).isTrue();
+        assertThat(new SpecimenType<HashMap>() {}.isMap()).isTrue();
     }
 
     @TestWithCases
@@ -190,24 +160,15 @@ class SpecimenTypeTest {
 
     @Test
     void isBoxed() {
-        assertThat(new SpecimenType<String>() {
-        }.isBoxed()).isFalse(); // false!
-        assertThat(new SpecimenType<Byte>() {
-        }.isBoxed()).isTrue();
-        assertThat(new SpecimenType<Short>() {
-        }.isBoxed()).isTrue();
-        assertThat(new SpecimenType<Integer>() {
-        }.isBoxed()).isTrue();
-        assertThat(new SpecimenType<Long>() {
-        }.isBoxed()).isTrue();
-        assertThat(new SpecimenType<Float>() {
-        }.isBoxed()).isTrue();
-        assertThat(new SpecimenType<Double>() {
-        }.isBoxed()).isTrue();
-        assertThat(new SpecimenType<Character>() {
-        }.isBoxed()).isTrue();
-        assertThat(new SpecimenType<Boolean>() {
-        }.isBoxed()).isTrue();
+        assertThat(new SpecimenType<String>() {}.isBoxed()).isFalse(); // false!
+        assertThat(new SpecimenType<Byte>() {}.isBoxed()).isTrue();
+        assertThat(new SpecimenType<Short>() {}.isBoxed()).isTrue();
+        assertThat(new SpecimenType<Integer>() {}.isBoxed()).isTrue();
+        assertThat(new SpecimenType<Long>() {}.isBoxed()).isTrue();
+        assertThat(new SpecimenType<Float>() {}.isBoxed()).isTrue();
+        assertThat(new SpecimenType<Double>() {}.isBoxed()).isTrue();
+        assertThat(new SpecimenType<Character>() {}.isBoxed()).isTrue();
+        assertThat(new SpecimenType<Boolean>() {}.isBoxed()).isTrue();
     }
 
     @TestWithCases
@@ -242,24 +203,21 @@ class SpecimenTypeTest {
     void isEnum() {
         assertThat(SpecimenType.fromClass(String.class).isEnum()).isFalse();
         assertThat(SpecimenType.fromClass(TestEnum.class).isEnum()).isTrue();
-        assertThat(new SpecimenType<TestEnum>() {
-        }.isEnum()).isTrue();
+        assertThat(new SpecimenType<TestEnum>() {}.isEnum()).isTrue();
     }
 
     @Test
     void isArray() {
         assertThat(SpecimenType.fromClass(List.class).isArray()).isFalse();
         assertThat(SpecimenType.fromClass(int[].class).isArray()).isTrue();
-        assertThat(new SpecimenType<Integer[]>() {
-        }.isArray()).isTrue();
+        assertThat(new SpecimenType<Integer[]>() {}.isArray()).isTrue();
     }
 
     @Test
     void isInterface() {
         assertThat(SpecimenType.fromClass(String.class).isInterface()).isFalse();
         assertThat(SpecimenType.fromClass(List.class).isInterface()).isTrue();
-        assertThat(new SpecimenType<ITestGeneric<String, List<Optional>>>() {
-        }.isInterface()).isTrue();
+        assertThat(new SpecimenType<ITestGeneric<String, List<Optional>>>() {}.isInterface()).isTrue();
     }
 
     @Test
@@ -270,14 +228,14 @@ class SpecimenTypeTest {
 
     @Test
     void isTimeType() {
-        assertThat(new SpecimenType<String>(){}.isTimeType()).isFalse(); // false
-        assertThat(new SpecimenType<Duration>(){}.isTimeType()).isTrue();
-        assertThat(new SpecimenType<JapaneseEra>(){}.isTimeType()).isTrue();
-        assertThat(new SpecimenType<MonthDay>(){}.isTimeType()).isTrue();
-        assertThat(new SpecimenType<Period>(){}.isTimeType()).isTrue();
-        assertThat(new SpecimenType<ZoneId>(){}.isTimeType()).isTrue();
-        assertThat(new SpecimenType<ZoneOffset>(){}.isTimeType()).isTrue();
-        assertThat(new SpecimenType<ZonedDateTime>(){}.isTimeType()).isTrue();
+        assertThat(new SpecimenType<String>() {}.isTimeType()).isFalse(); // false
+        assertThat(new SpecimenType<Duration>() {}.isTimeType()).isTrue();
+        assertThat(new SpecimenType<JapaneseEra>() {}.isTimeType()).isTrue();
+        assertThat(new SpecimenType<MonthDay>() {}.isTimeType()).isTrue();
+        assertThat(new SpecimenType<Period>() {}.isTimeType()).isTrue();
+        assertThat(new SpecimenType<ZoneId>() {}.isTimeType()).isTrue();
+        assertThat(new SpecimenType<ZoneOffset>() {}.isTimeType()).isTrue();
+        assertThat(new SpecimenType<ZonedDateTime>() {}.isTimeType()).isTrue();
     }
 
     @TestWithCases
@@ -299,9 +257,9 @@ class SpecimenTypeTest {
 
     @Test
     void isSpecialType() {
-        assertThat(new SpecimenType<String>(){}.isSpecialType()).isFalse(); // false
-        assertThat(new SpecimenType<URI>(){}.isSpecialType()).isTrue();
-        assertThat(new SpecimenType<File>(){}.isSpecialType()).isTrue();
+        assertThat(new SpecimenType<String>() {}.isSpecialType()).isFalse(); // false
+        assertThat(new SpecimenType<URI>() {}.isSpecialType()).isTrue();
+        assertThat(new SpecimenType<File>() {}.isSpecialType()).isTrue();
     }
 
     @TestWithCases
@@ -314,8 +272,7 @@ class SpecimenTypeTest {
 
     @Test
     void getGenericTypeArgument() {
-        var sut = new SpecimenType<Map<String, Optional<Integer>>>() {
-        };
+        var sut = new SpecimenType<Map<String, Optional<Integer>>>() {};
 
         assertThat(sut.getGenericTypeArgument(0)).isEqualTo(String.class);
         assertThat(sut.getGenericTypeArgument(1)).isInstanceOf(ParameterizedType.class);
@@ -330,8 +287,7 @@ class SpecimenTypeTest {
 
     @Test
     void getGenericTypeArguments() {
-        var sut = new SpecimenType<Map<String, Optional<Integer>>>() {
-        };
+        var sut = new SpecimenType<Map<String, Optional<Integer>>>() {};
 
         assertThat(sut.getGenericTypeArguments()).hasSize(2);
         assertThat(sut.getGenericTypeArguments()[0]).isEqualTo(String.class);
@@ -347,8 +303,7 @@ class SpecimenTypeTest {
 
     @Test
     void getTypeParameterName() {
-        var sut = new SpecimenType<TestObjectGeneric<String, Optional<Integer>>>() {
-        };
+        var sut = new SpecimenType<TestObjectGeneric<String, Optional<Integer>>>() {};
 
         assertThat(sut.getTypeParameterName(0)).isEqualTo("T");
         assertThat(sut.getTypeParameterName(1)).isEqualTo("U");
@@ -361,8 +316,7 @@ class SpecimenTypeTest {
 
     @Test
     void getTypeParameterNames() {
-        var sut = new SpecimenType<TestObjectGeneric<String, Optional<Integer>>>() {
-        };
+        var sut = new SpecimenType<TestObjectGeneric<String, Optional<Integer>>>() {};
 
         assertThat(sut.getTypeParameterNames()).hasSize(2);
         assertThat(sut.getTypeParameterNames()[0]).isEqualTo("T");
@@ -376,10 +330,8 @@ class SpecimenTypeTest {
 
     @Test
     void getComponentType() {
-        assertThat(new SpecimenType<int[]>() {
-        }.getComponentType()).isEqualTo(int.class);
-        assertThat(new SpecimenType<Integer[]>() {
-        }.getComponentType()).isEqualTo(Integer.class);
+        assertThat(new SpecimenType<int[]>() {}.getComponentType()).isEqualTo(int.class);
+        assertThat(new SpecimenType<Integer[]>() {}.getComponentType()).isEqualTo(Integer.class);
 
         assertThatExceptionOfType(SpecimenTypeException.class)
                 .isThrownBy(() -> SpecimenType.fromClass(String.class).getComponentType())
@@ -397,8 +349,7 @@ class SpecimenTypeTest {
     @Test
     void getEnumConstants() {
         assertThat(SpecimenType.fromClass(TestEnum.class).getEnumConstants().length).isEqualTo(3);
-        assertThat(new SpecimenType<TestEnum>() {
-        }.getEnumConstants().length).isEqualTo(3);
+        assertThat(new SpecimenType<TestEnum>() {}.getEnumConstants().length).isEqualTo(3);
 
         assertThatExceptionOfType(SpecimenTypeException.class)
                 .isThrownBy(() -> SpecimenType.fromClass(String.class).getEnumConstants())
@@ -409,18 +360,14 @@ class SpecimenTypeTest {
     @Test
     void getName() {
         assertThat(SpecimenType.fromClass(Optional.class).getName()).isEqualTo("java.util.Optional");
-        assertThat(new SpecimenType<Optional<String>>() {
-        }.getName()).isEqualTo("java.util.Optional<java.lang.String>");
+        assertThat(new SpecimenType<Optional<String>>() {}.getName()).isEqualTo("java.util.Optional<java.lang.String>");
     }
 
     @Test
     void asParameterizedType() {
-        assertThat(new SpecimenType<Optional<String>>() {
-        }.asParameterizedType().getRawType()).isEqualTo(Optional.class);
-        assertThat(new SpecimenType<Optional<String>>() {
-        }.asParameterizedType().getActualTypeArguments().length).isEqualTo(1);
-        assertThat(new SpecimenType<Optional<String>>() {
-        }.asParameterizedType().getActualTypeArguments()[0].getTypeName()).isEqualTo(String.class.getName());
+        assertThat(new SpecimenType<Optional<String>>() {}.asParameterizedType().getRawType()).isEqualTo(Optional.class);
+        assertThat(new SpecimenType<Optional<String>>() {}.asParameterizedType().getActualTypeArguments().length).isEqualTo(1);
+        assertThat(new SpecimenType<Optional<String>>() {}.asParameterizedType().getActualTypeArguments()[0].getTypeName()).isEqualTo(String.class.getName());
     }
 
     @TestWithCases
@@ -440,8 +387,7 @@ class SpecimenTypeTest {
 
     @Test
     void fromType() {
-        Type type = new SpecimenType<Optional<String>>() {
-        }.asParameterizedType();
+        Type type = new SpecimenType<Optional<String>>() {}.asParameterizedType();
 
         var sut = SpecimenType.fromClass(type);
 
@@ -452,8 +398,7 @@ class SpecimenTypeTest {
 
     @Test
     void createForObjectClass() {
-        var sut = new SpecimenType<String>() {
-        };
+        var sut = new SpecimenType<String>() {};
 
         assertThat(sut.asClass()).isEqualTo(String.class);
         assertThat(sut.isParameterized()).isFalse();
@@ -464,8 +409,7 @@ class SpecimenTypeTest {
 
     @Test
     void createForGenericClass() {
-        var sut = new SpecimenType<Optional<String>>() {
-        };
+        var sut = new SpecimenType<Optional<String>>() {};
 
         assertThat(sut.asClass()).isEqualTo(Optional.class);
         assertThat(sut.isParameterized()).isTrue();
@@ -476,8 +420,7 @@ class SpecimenTypeTest {
 
     @Test
     void createForListInterface() {
-        var sut = new SpecimenType<List<String>>() {
-        };
+        var sut = new SpecimenType<List<String>>() {};
 
         assertThat(sut.asClass()).isEqualTo(List.class);
         assertThat(sut.isParameterized()).isTrue();
@@ -488,8 +431,7 @@ class SpecimenTypeTest {
 
     @Test
     void createForMapInterface() {
-        var sut = new SpecimenType<Map<String, Integer>>() {
-        };
+        var sut = new SpecimenType<Map<String, Integer>>() {};
 
         assertThat(sut.asClass()).isEqualTo(Map.class);
         assertThat(sut.isParameterized()).isTrue();
@@ -501,8 +443,7 @@ class SpecimenTypeTest {
 
     @Test
     void getDeclaredConstructors() {
-        var sut = new SpecimenType<TestObjectWithAllConstructors>() {
-        };
+        var sut = new SpecimenType<TestObjectWithAllConstructors>() {};
 
         var actual = sut.getDeclaredConstructors();
 
@@ -511,8 +452,7 @@ class SpecimenTypeTest {
 
     @Test
     void getFactoryMethods() {
-        var sut = new SpecimenType<TestObjectWithStaticMethods>() {
-        };
+        var sut = new SpecimenType<TestObjectWithStaticMethods>() {};
 
         var actual = sut.getFactoryMethods();
 

--- a/src/test/java/com/github/nylle/javafixture/SpecimenTypeTest.java
+++ b/src/test/java/com/github/nylle/javafixture/SpecimenTypeTest.java
@@ -13,8 +13,10 @@ import com.github.nylle.javafixture.testobjects.TestObjectWithStaticMethods;
 import com.github.nylle.javafixture.testobjects.TestWildCardType;
 import org.junit.jupiter.api.Test;
 
+import java.io.File;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.net.URI;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -60,13 +62,16 @@ class SpecimenTypeTest {
 
     @Test
     void asClass() {
-        assertThat(new SpecimenType<String>() {}.asClass()).isEqualTo(String.class);
+        assertThat(new SpecimenType<String>() {
+        }.asClass()).isEqualTo(String.class);
     }
 
     @Test
     void isParametrized() {
-        assertThat(new SpecimenType<String>() {}.isParameterized()).isFalse();
-        assertThat(new SpecimenType<Optional<String>>() {}.isParameterized()).isTrue();
+        assertThat(new SpecimenType<String>() {
+        }.isParameterized()).isFalse();
+        assertThat(new SpecimenType<Optional<String>>() {
+        }.isParameterized()).isTrue();
     }
 
     @Test
@@ -86,24 +91,42 @@ class SpecimenTypeTest {
 
     @Test
     void isCollection() {
-        assertThat(new SpecimenType<Collection<String>>() {}.isCollection()).isTrue();
-        assertThat(new SpecimenType<List<String>>() {}.isCollection()).isTrue();
-        assertThat(new SpecimenType<NavigableSet<String>>() {}.isCollection()).isTrue();
-        assertThat(new SpecimenType<SortedSet<String>>() {}.isCollection()).isTrue();
-        assertThat(new SpecimenType<Set<String>>() {}.isCollection()).isTrue();
-        assertThat(new SpecimenType<Deque<String>>() {}.isCollection()).isTrue();
-        assertThat(new SpecimenType<BlockingDeque<String>>() {}.isCollection()).isTrue();
-        assertThat(new SpecimenType<Queue<String>>() {}.isCollection()).isTrue();
-        assertThat(new SpecimenType<BlockingQueue<String>>() {}.isCollection()).isTrue();
-        assertThat(new SpecimenType<TransferQueue<String>>() {}.isCollection()).isTrue();
-        assertThat(new SpecimenType<ArrayList<String>>() {}.isCollection()).isTrue();
-        assertThat(new SpecimenType<HashSet<String>>() {}.isCollection()).isTrue();
-        assertThat(new SpecimenType<TreeSet<String>>() {}.isCollection()).isTrue();
-        assertThat(new SpecimenType<ArrayDeque<String>>() {}.isCollection()).isTrue();
-        assertThat(new SpecimenType<LinkedBlockingDeque<String>>() {}.isCollection()).isTrue();
-        assertThat(new SpecimenType<LinkedList<String>>() {}.isCollection()).isTrue();
-        assertThat(new SpecimenType<LinkedBlockingQueue<String>>() {}.isCollection()).isTrue();
-        assertThat(new SpecimenType<LinkedTransferQueue<String>>() {}.isCollection()).isTrue();
+        assertThat(new SpecimenType<Collection<String>>() {
+        }.isCollection()).isTrue();
+        assertThat(new SpecimenType<List<String>>() {
+        }.isCollection()).isTrue();
+        assertThat(new SpecimenType<NavigableSet<String>>() {
+        }.isCollection()).isTrue();
+        assertThat(new SpecimenType<SortedSet<String>>() {
+        }.isCollection()).isTrue();
+        assertThat(new SpecimenType<Set<String>>() {
+        }.isCollection()).isTrue();
+        assertThat(new SpecimenType<Deque<String>>() {
+        }.isCollection()).isTrue();
+        assertThat(new SpecimenType<BlockingDeque<String>>() {
+        }.isCollection()).isTrue();
+        assertThat(new SpecimenType<Queue<String>>() {
+        }.isCollection()).isTrue();
+        assertThat(new SpecimenType<BlockingQueue<String>>() {
+        }.isCollection()).isTrue();
+        assertThat(new SpecimenType<TransferQueue<String>>() {
+        }.isCollection()).isTrue();
+        assertThat(new SpecimenType<ArrayList<String>>() {
+        }.isCollection()).isTrue();
+        assertThat(new SpecimenType<HashSet<String>>() {
+        }.isCollection()).isTrue();
+        assertThat(new SpecimenType<TreeSet<String>>() {
+        }.isCollection()).isTrue();
+        assertThat(new SpecimenType<ArrayDeque<String>>() {
+        }.isCollection()).isTrue();
+        assertThat(new SpecimenType<LinkedBlockingDeque<String>>() {
+        }.isCollection()).isTrue();
+        assertThat(new SpecimenType<LinkedList<String>>() {
+        }.isCollection()).isTrue();
+        assertThat(new SpecimenType<LinkedBlockingQueue<String>>() {
+        }.isCollection()).isTrue();
+        assertThat(new SpecimenType<LinkedTransferQueue<String>>() {
+        }.isCollection()).isTrue();
     }
 
     @TestWithCases
@@ -131,15 +154,24 @@ class SpecimenTypeTest {
 
     @Test
     void isMap() {
-        assertThat(new SpecimenType<Map>(){}.isMap()).isTrue();
-        assertThat(new SpecimenType<ConcurrentNavigableMap>(){}.isMap()).isTrue();
-        assertThat(new SpecimenType<ConcurrentMap>(){}.isMap()).isTrue();
-        assertThat(new SpecimenType<NavigableMap>(){}.isMap()).isTrue();
-        assertThat(new SpecimenType<SortedMap>(){}.isMap()).isTrue();
-        assertThat(new SpecimenType<TreeMap>(){}.isMap()).isTrue();
-        assertThat(new SpecimenType<ConcurrentSkipListMap>(){}.isMap()).isTrue();
-        assertThat(new SpecimenType<ConcurrentHashMap>(){}.isMap()).isTrue();
-        assertThat(new SpecimenType<HashMap>(){}.isMap()).isTrue();
+        assertThat(new SpecimenType<Map>() {
+        }.isMap()).isTrue();
+        assertThat(new SpecimenType<ConcurrentNavigableMap>() {
+        }.isMap()).isTrue();
+        assertThat(new SpecimenType<ConcurrentMap>() {
+        }.isMap()).isTrue();
+        assertThat(new SpecimenType<NavigableMap>() {
+        }.isMap()).isTrue();
+        assertThat(new SpecimenType<SortedMap>() {
+        }.isMap()).isTrue();
+        assertThat(new SpecimenType<TreeMap>() {
+        }.isMap()).isTrue();
+        assertThat(new SpecimenType<ConcurrentSkipListMap>() {
+        }.isMap()).isTrue();
+        assertThat(new SpecimenType<ConcurrentHashMap>() {
+        }.isMap()).isTrue();
+        assertThat(new SpecimenType<HashMap>() {
+        }.isMap()).isTrue();
     }
 
     @TestWithCases
@@ -158,15 +190,24 @@ class SpecimenTypeTest {
 
     @Test
     void isBoxed() {
-        assertThat(new SpecimenType<String>() {}.isBoxed()).isFalse(); // false!
-        assertThat(new SpecimenType<Byte>() {}.isBoxed()).isTrue();
-        assertThat(new SpecimenType<Short>() {}.isBoxed()).isTrue();
-        assertThat(new SpecimenType<Integer>() {}.isBoxed()).isTrue();
-        assertThat(new SpecimenType<Long>() {}.isBoxed()).isTrue();
-        assertThat(new SpecimenType<Float>() {}.isBoxed()).isTrue();
-        assertThat(new SpecimenType<Double>() {}.isBoxed()).isTrue();
-        assertThat(new SpecimenType<Character>() {}.isBoxed()).isTrue();
-        assertThat(new SpecimenType<Boolean>() {}.isBoxed()).isTrue();
+        assertThat(new SpecimenType<String>() {
+        }.isBoxed()).isFalse(); // false!
+        assertThat(new SpecimenType<Byte>() {
+        }.isBoxed()).isTrue();
+        assertThat(new SpecimenType<Short>() {
+        }.isBoxed()).isTrue();
+        assertThat(new SpecimenType<Integer>() {
+        }.isBoxed()).isTrue();
+        assertThat(new SpecimenType<Long>() {
+        }.isBoxed()).isTrue();
+        assertThat(new SpecimenType<Float>() {
+        }.isBoxed()).isTrue();
+        assertThat(new SpecimenType<Double>() {
+        }.isBoxed()).isTrue();
+        assertThat(new SpecimenType<Character>() {
+        }.isBoxed()).isTrue();
+        assertThat(new SpecimenType<Boolean>() {
+        }.isBoxed()).isTrue();
     }
 
     @TestWithCases
@@ -201,21 +242,24 @@ class SpecimenTypeTest {
     void isEnum() {
         assertThat(SpecimenType.fromClass(String.class).isEnum()).isFalse();
         assertThat(SpecimenType.fromClass(TestEnum.class).isEnum()).isTrue();
-        assertThat(new SpecimenType<TestEnum>() {}.isEnum()).isTrue();
+        assertThat(new SpecimenType<TestEnum>() {
+        }.isEnum()).isTrue();
     }
 
     @Test
     void isArray() {
         assertThat(SpecimenType.fromClass(List.class).isArray()).isFalse();
         assertThat(SpecimenType.fromClass(int[].class).isArray()).isTrue();
-        assertThat(new SpecimenType<Integer[]>() {}.isArray()).isTrue();
+        assertThat(new SpecimenType<Integer[]>() {
+        }.isArray()).isTrue();
     }
 
     @Test
     void isInterface() {
         assertThat(SpecimenType.fromClass(String.class).isInterface()).isFalse();
         assertThat(SpecimenType.fromClass(List.class).isInterface()).isTrue();
-        assertThat(new SpecimenType<ITestGeneric<String, List<Optional>>>() {}.isInterface()).isTrue();
+        assertThat(new SpecimenType<ITestGeneric<String, List<Optional>>>() {
+        }.isInterface()).isTrue();
     }
 
     @Test
@@ -254,8 +298,24 @@ class SpecimenTypeTest {
     }
 
     @Test
+    void isSpecialType() {
+        assertThat(new SpecimenType<String>(){}.isSpecialType()).isFalse(); // false
+        assertThat(new SpecimenType<URI>(){}.isSpecialType()).isTrue();
+        assertThat(new SpecimenType<File>(){}.isSpecialType()).isTrue();
+    }
+
+    @TestWithCases
+    @TestCase(class1 = String.class, bool2 = false)
+    @TestCase(class1 = File.class, bool2 = true)
+    @TestCase(class1 = URI.class, bool2 = true)
+    void isSpecialTypeFromClass(Class<?> value, boolean expected) {
+        assertThat(SpecimenType.fromClass(value).isSpecialType()).isEqualTo(expected);
+    }
+
+    @Test
     void getGenericTypeArgument() {
-        var sut = new SpecimenType<Map<String, Optional<Integer>>>(){};
+        var sut = new SpecimenType<Map<String, Optional<Integer>>>() {
+        };
 
         assertThat(sut.getGenericTypeArgument(0)).isEqualTo(String.class);
         assertThat(sut.getGenericTypeArgument(1)).isInstanceOf(ParameterizedType.class);
@@ -270,7 +330,8 @@ class SpecimenTypeTest {
 
     @Test
     void getGenericTypeArguments() {
-        var sut = new SpecimenType<Map<String, Optional<Integer>>>(){};
+        var sut = new SpecimenType<Map<String, Optional<Integer>>>() {
+        };
 
         assertThat(sut.getGenericTypeArguments()).hasSize(2);
         assertThat(sut.getGenericTypeArguments()[0]).isEqualTo(String.class);
@@ -286,7 +347,8 @@ class SpecimenTypeTest {
 
     @Test
     void getTypeParameterName() {
-        var sut = new SpecimenType<TestObjectGeneric<String, Optional<Integer>>>(){};
+        var sut = new SpecimenType<TestObjectGeneric<String, Optional<Integer>>>() {
+        };
 
         assertThat(sut.getTypeParameterName(0)).isEqualTo("T");
         assertThat(sut.getTypeParameterName(1)).isEqualTo("U");
@@ -299,7 +361,8 @@ class SpecimenTypeTest {
 
     @Test
     void getTypeParameterNames() {
-        var sut = new SpecimenType<TestObjectGeneric<String, Optional<Integer>>>(){};
+        var sut = new SpecimenType<TestObjectGeneric<String, Optional<Integer>>>() {
+        };
 
         assertThat(sut.getTypeParameterNames()).hasSize(2);
         assertThat(sut.getTypeParameterNames()[0]).isEqualTo("T");
@@ -313,8 +376,10 @@ class SpecimenTypeTest {
 
     @Test
     void getComponentType() {
-        assertThat(new SpecimenType<int[]>(){}.getComponentType()).isEqualTo(int.class);
-        assertThat(new SpecimenType<Integer[]>(){}.getComponentType()).isEqualTo(Integer.class);
+        assertThat(new SpecimenType<int[]>() {
+        }.getComponentType()).isEqualTo(int.class);
+        assertThat(new SpecimenType<Integer[]>() {
+        }.getComponentType()).isEqualTo(Integer.class);
 
         assertThatExceptionOfType(SpecimenTypeException.class)
                 .isThrownBy(() -> SpecimenType.fromClass(String.class).getComponentType())
@@ -332,7 +397,8 @@ class SpecimenTypeTest {
     @Test
     void getEnumConstants() {
         assertThat(SpecimenType.fromClass(TestEnum.class).getEnumConstants().length).isEqualTo(3);
-        assertThat(new SpecimenType<TestEnum>(){}.getEnumConstants().length).isEqualTo(3);
+        assertThat(new SpecimenType<TestEnum>() {
+        }.getEnumConstants().length).isEqualTo(3);
 
         assertThatExceptionOfType(SpecimenTypeException.class)
                 .isThrownBy(() -> SpecimenType.fromClass(String.class).getEnumConstants())
@@ -343,14 +409,18 @@ class SpecimenTypeTest {
     @Test
     void getName() {
         assertThat(SpecimenType.fromClass(Optional.class).getName()).isEqualTo("java.util.Optional");
-        assertThat(new SpecimenType<Optional<String>>(){}.getName()).isEqualTo("java.util.Optional<java.lang.String>");
+        assertThat(new SpecimenType<Optional<String>>() {
+        }.getName()).isEqualTo("java.util.Optional<java.lang.String>");
     }
 
     @Test
     void asParameterizedType() {
-        assertThat(new SpecimenType<Optional<String>>() {}.asParameterizedType().getRawType()).isEqualTo(Optional.class);
-        assertThat(new SpecimenType<Optional<String>>() {}.asParameterizedType().getActualTypeArguments().length).isEqualTo(1);
-        assertThat(new SpecimenType<Optional<String>>() {}.asParameterizedType().getActualTypeArguments()[0].getTypeName()).isEqualTo(String.class.getName());
+        assertThat(new SpecimenType<Optional<String>>() {
+        }.asParameterizedType().getRawType()).isEqualTo(Optional.class);
+        assertThat(new SpecimenType<Optional<String>>() {
+        }.asParameterizedType().getActualTypeArguments().length).isEqualTo(1);
+        assertThat(new SpecimenType<Optional<String>>() {
+        }.asParameterizedType().getActualTypeArguments()[0].getTypeName()).isEqualTo(String.class.getName());
     }
 
     @TestWithCases
@@ -370,7 +440,8 @@ class SpecimenTypeTest {
 
     @Test
     void fromType() {
-        Type type = new SpecimenType<Optional<String>>() {}.asParameterizedType();
+        Type type = new SpecimenType<Optional<String>>() {
+        }.asParameterizedType();
 
         var sut = SpecimenType.fromClass(type);
 
@@ -381,7 +452,8 @@ class SpecimenTypeTest {
 
     @Test
     void createForObjectClass() {
-        var sut = new SpecimenType<String>() {};
+        var sut = new SpecimenType<String>() {
+        };
 
         assertThat(sut.asClass()).isEqualTo(String.class);
         assertThat(sut.isParameterized()).isFalse();
@@ -392,7 +464,8 @@ class SpecimenTypeTest {
 
     @Test
     void createForGenericClass() {
-        var sut = new SpecimenType<Optional<String>>() {};
+        var sut = new SpecimenType<Optional<String>>() {
+        };
 
         assertThat(sut.asClass()).isEqualTo(Optional.class);
         assertThat(sut.isParameterized()).isTrue();
@@ -403,7 +476,8 @@ class SpecimenTypeTest {
 
     @Test
     void createForListInterface() {
-        var sut = new SpecimenType<List<String>>() {};
+        var sut = new SpecimenType<List<String>>() {
+        };
 
         assertThat(sut.asClass()).isEqualTo(List.class);
         assertThat(sut.isParameterized()).isTrue();
@@ -414,7 +488,8 @@ class SpecimenTypeTest {
 
     @Test
     void createForMapInterface() {
-        var sut = new SpecimenType<Map<String, Integer>>() {};
+        var sut = new SpecimenType<Map<String, Integer>>() {
+        };
 
         assertThat(sut.asClass()).isEqualTo(Map.class);
         assertThat(sut.isParameterized()).isTrue();
@@ -426,7 +501,8 @@ class SpecimenTypeTest {
 
     @Test
     void getDeclaredConstructors() {
-        var sut = new SpecimenType<TestObjectWithAllConstructors>() {};
+        var sut = new SpecimenType<TestObjectWithAllConstructors>() {
+        };
 
         var actual = sut.getDeclaredConstructors();
 
@@ -435,7 +511,8 @@ class SpecimenTypeTest {
 
     @Test
     void getFactoryMethods() {
-        var sut = new SpecimenType<TestObjectWithStaticMethods>() {};
+        var sut = new SpecimenType<TestObjectWithStaticMethods>() {
+        };
 
         var actual = sut.getFactoryMethods();
 
@@ -444,7 +521,7 @@ class SpecimenTypeTest {
 
     @Test
     void castToClass_CanHandleWildcardTypesWithUpperBounds() {
-        var upperBounds = new Type[] { Integer.class};
+        var upperBounds = new Type[]{Integer.class};
 
         var wildcardType = new TestWildCardType(upperBounds, new Type[0]);
 
@@ -453,7 +530,7 @@ class SpecimenTypeTest {
 
     @Test
     void castToClass_CanHandleWildcardTypesWithLowerBounds() {
-        var lowerBounds = new Type[] { Integer.class};
+        var lowerBounds = new Type[]{Integer.class};
 
         var wildcardType = new TestWildCardType(new Type[0], lowerBounds);
 

--- a/src/test/java/com/github/nylle/javafixture/specimen/SpecialSpecimenTest.java
+++ b/src/test/java/com/github/nylle/javafixture/specimen/SpecialSpecimenTest.java
@@ -1,0 +1,91 @@
+package com.github.nylle.javafixture.specimen;
+
+
+import com.github.nylle.javafixture.Configuration;
+import com.github.nylle.javafixture.Context;
+import com.github.nylle.javafixture.CustomizationContext;
+import com.github.nylle.javafixture.SpecimenType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.lang.annotation.Annotation;
+import java.net.URI;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class SpecialSpecimenTest {
+    private Context context;
+
+    @BeforeEach
+    void setup() {
+        context = new Context(Configuration.configure());
+    }
+
+    @Nested
+    @DisplayName("constructor throws exception when called")
+    class ConstructorTest {
+        @Test
+        @DisplayName("with type other than File or URI")
+        void onlySpecialType() {
+            assertThatThrownBy(() -> new SpecialSpecimen<>(SpecimenType.fromClass(Map.class), context))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("type: " + Map.class.getName());
+        }
+
+        @Test
+        @DisplayName("without type")
+        void typeIsRequired() {
+            assertThatThrownBy(() -> new SpecialSpecimen<>(null, context))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("type: null");
+        }
+
+        @Test
+        @DisplayName("without context")
+        void contextIsRequired() {
+            assertThatThrownBy(() -> new SpecialSpecimen<>(SpecimenType.fromClass(File.class), null))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("context: null");
+        }
+
+    }
+    @Test
+    @DisplayName("creating two files creates two different files")
+    void createFile() {
+        var sut = new SpecialSpecimen<>(SpecimenType.fromClass(File.class), context);
+        var first = (File)sut.create(CustomizationContext.noContext(), new Annotation[0]);
+        var second = (File)sut.create(CustomizationContext.noContext(), new Annotation[0]);
+
+        assertThat(first.getAbsolutePath()).isNotEqualTo(second.getAbsolutePath());
+    }
+
+    @Test
+    @DisplayName("create file w/o context creates file with random name")
+    void createFileWithoutContext() {
+        var sut = new SpecialSpecimen<>(SpecimenType.fromClass(File.class), context);
+
+        var actual = (File)sut.create(new Annotation[0]);
+
+        assertThat( actual ).isNotNull();
+        assertThat( actual.getAbsolutePath() ).isNotEmpty();
+    }
+
+
+    @Test
+    @DisplayName("create URI creates URI with host, scheme and random path")
+    void craeteURI() {
+        var sut = new SpecialSpecimen<>(SpecimenType.fromClass(URI.class), context);
+        var actual = sut.create(CustomizationContext.noContext(), new Annotation[0]);
+
+        assertThat(actual).isInstanceOf(URI.class);
+        assertThat( ((URI)actual).getScheme() ).isEqualTo("https");
+        assertThat( ((URI)actual).getHost() ).isNotNull();
+        assertThat( ((URI)actual).getPath() ).isNotEmpty();
+    }
+
+}


### PR DESCRIPTION
Files and URIs cannot be constructed with any argument and therefore need "special" treatment.
We need selected constructors to build valid objects.

Using selected constructors for these makes this code work with a JDK 17 environment (even if the code is compiled with JDK 11)
This is a preparation step for JF-63