### PR TITLE
#61 Column validation annotation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>jakarta.persistence</groupId>
             <artifactId>jakarta.persistence-api</artifactId>
-            <version>3.0.0</version>
+            <version>2.2.3</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.github.nylle</groupId>
     <artifactId>javafixture</artifactId>
     <packaging>jar</packaging>
-    <version>2.8.0</version>
+    <version>2.8.1</version>
 
     <name>JavaFixture</name>
     <url>https://github.com/Nylle/JavaFixture</url>
@@ -41,6 +41,11 @@
             <groupId>jakarta.validation</groupId>
             <artifactId>jakarta.validation-api</artifactId>
             <version>2.0.2</version>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.persistence</groupId>
+            <artifactId>jakarta.persistence-api</artifactId>
+            <version>3.0.0</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/src/main/java/com/github/nylle/javafixture/annotations/fixture/TestWithFixture.java
+++ b/src/main/java/com/github/nylle/javafixture/annotations/fixture/TestWithFixture.java
@@ -15,7 +15,7 @@ import java.lang.annotation.Target;
 @ArgumentsSource(JavaFixtureProvider.class)
 @ParameterizedTest
 public @interface TestWithFixture {
-    int minCollectionSize() default 10;
+    int minCollectionSize() default 2;
 
     int maxCollectionSize() default 10;
 

--- a/src/main/java/com/github/nylle/javafixture/specimen/PrimitiveSpecimen.java
+++ b/src/main/java/com/github/nylle/javafixture/specimen/PrimitiveSpecimen.java
@@ -9,9 +9,8 @@ import com.github.nylle.javafixture.SpecimenException;
 import com.github.nylle.javafixture.SpecimenType;
 import com.github.nylle.javafixture.specimen.constraints.StringConstraints;
 
-import jakarta.persistence.Column;
-
 import java.lang.annotation.Annotation;
+import javax.persistence.Column;
 import javax.validation.constraints.Size;
 
 import static com.github.nylle.javafixture.CustomizationContext.noContext;

--- a/src/main/java/com/github/nylle/javafixture/specimen/PrimitiveSpecimen.java
+++ b/src/main/java/com/github/nylle/javafixture/specimen/PrimitiveSpecimen.java
@@ -9,6 +9,8 @@ import com.github.nylle.javafixture.SpecimenException;
 import com.github.nylle.javafixture.SpecimenType;
 import com.github.nylle.javafixture.specimen.constraints.StringConstraints;
 
+import jakarta.persistence.Column;
+
 import java.lang.annotation.Annotation;
 import javax.validation.constraints.Size;
 
@@ -93,6 +95,8 @@ public class PrimitiveSpecimen<T> implements ISpecimen<T> {
         for (var annotation : annotations) {
             if(Size.class.isAssignableFrom(annotation.annotationType())) {
                 constraints = new StringConstraints(((Size)annotation).min(), ((Size)annotation).max());
+            } else if(Column.class.isAssignableFrom(annotation.annotationType())) {
+                constraints = new StringConstraints(0, ((Column) annotation).length());
             }
         }
         return constraints;

--- a/src/test/java/com/github/nylle/javafixture/FixtureWithValidationTest.java
+++ b/src/test/java/com/github/nylle/javafixture/FixtureWithValidationTest.java
@@ -20,6 +20,13 @@ class FixtureWithValidationTest {
         assertThat(sut.getWithColumnLengthAnnotation().length()).isBetween(0, 5);
     }
 
+    @Test
+    void lastOfMultipleAnnotationsWins() {
+        var sut = new Fixture().create(TestObjectWithJavaxValidationAnnotations.class);
+
+        assertThat(sut.getWithColumnLengthAnnotationAndMaxAnnotation().length()).isBetween(0, 5);
+    }
+
     @TestWithFixture
     void fixtureWillAlwaysCreateValidObject(TestObjectWithJavaxValidationAnnotations sut) {
         var factory = Validation.buildDefaultValidatorFactory();

--- a/src/test/java/com/github/nylle/javafixture/FixtureWithValidationTest.java
+++ b/src/test/java/com/github/nylle/javafixture/FixtureWithValidationTest.java
@@ -8,7 +8,7 @@ import javax.validation.Validation;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class FixtureWithValidationTest {
+class FixtureWithValidationTest {
 
     @Test
     void javaxSizeAnnotationIsSupported() {
@@ -17,6 +17,7 @@ public class FixtureWithValidationTest {
         assertThat(sut.getWithMinAnnotation().length()).isGreaterThanOrEqualTo(5);
         assertThat(sut.getWithMaxAnnotation().length()).isLessThanOrEqualTo(100);
         assertThat(sut.getWithMinMaxAnnotation().length()).isBetween(3, 6);
+        assertThat(sut.getWithColumnLengthAnnotation().length()).isBetween(0, 5);
     }
 
     @TestWithFixture
@@ -24,10 +25,8 @@ public class FixtureWithValidationTest {
         var factory = Validation.buildDefaultValidatorFactory();
         var validator = factory.getValidator();
         var violations = validator.validate(sut);
-        assertThat( violations ).isEmpty();
 
-
-
+        assertThat(violations).isEmpty();
     }
 
 }

--- a/src/test/java/com/github/nylle/javafixture/testobjects/TestObjectWithJavaxValidationAnnotations.java
+++ b/src/test/java/com/github/nylle/javafixture/testobjects/TestObjectWithJavaxValidationAnnotations.java
@@ -17,6 +17,10 @@ public class TestObjectWithJavaxValidationAnnotations {
     @Column(length = 5)
     private String withColumnLengthAnnotation;
 
+    @Size(max = 100)
+    @Column(length = 5)
+    private String withColumnLengthAnnotationAndMaxAnnotation;
+
     public String getWithMinMaxAnnotation() {
         return withMinMaxAnnotation;
     }
@@ -31,5 +35,9 @@ public class TestObjectWithJavaxValidationAnnotations {
 
     public String getWithColumnLengthAnnotation() {
         return withColumnLengthAnnotation;
+    }
+
+    public String getWithColumnLengthAnnotationAndMaxAnnotation() {
+        return withColumnLengthAnnotationAndMaxAnnotation;
     }
 }

--- a/src/test/java/com/github/nylle/javafixture/testobjects/TestObjectWithJavaxValidationAnnotations.java
+++ b/src/test/java/com/github/nylle/javafixture/testobjects/TestObjectWithJavaxValidationAnnotations.java
@@ -19,7 +19,7 @@ public class TestObjectWithJavaxValidationAnnotations {
 
     @Size(max = 100)
     @Column(length = 5)
-    private String withColumnLengthAnnotationAndMaxAnnotation;
+    private String withMaxAnnotationAndColumnLengthAnnotation;
 
     public String getWithMinMaxAnnotation() {
         return withMinMaxAnnotation;
@@ -38,6 +38,6 @@ public class TestObjectWithJavaxValidationAnnotations {
     }
 
     public String getWithColumnLengthAnnotationAndMaxAnnotation() {
-        return withColumnLengthAnnotationAndMaxAnnotation;
+        return withMaxAnnotationAndColumnLengthAnnotation;
     }
 }

--- a/src/test/java/com/github/nylle/javafixture/testobjects/TestObjectWithJavaxValidationAnnotations.java
+++ b/src/test/java/com/github/nylle/javafixture/testobjects/TestObjectWithJavaxValidationAnnotations.java
@@ -1,7 +1,7 @@
 package com.github.nylle.javafixture.testobjects;
 
-import jakarta.persistence.Column;
 
+import javax.persistence.Column;
 import javax.validation.constraints.Size;
 
 public class TestObjectWithJavaxValidationAnnotations {

--- a/src/test/java/com/github/nylle/javafixture/testobjects/TestObjectWithJavaxValidationAnnotations.java
+++ b/src/test/java/com/github/nylle/javafixture/testobjects/TestObjectWithJavaxValidationAnnotations.java
@@ -1,5 +1,7 @@
 package com.github.nylle.javafixture.testobjects;
 
+import jakarta.persistence.Column;
+
 import javax.validation.constraints.Size;
 
 public class TestObjectWithJavaxValidationAnnotations {
@@ -12,6 +14,9 @@ public class TestObjectWithJavaxValidationAnnotations {
     @Size(max = 100)
     private String withMaxAnnotation;
 
+    @Column(length = 5)
+    private String withColumnLengthAnnotation;
+
     public String getWithMinMaxAnnotation() {
         return withMinMaxAnnotation;
     }
@@ -22,5 +27,9 @@ public class TestObjectWithJavaxValidationAnnotations {
 
     public String getWithMaxAnnotation() {
         return withMaxAnnotation;
+    }
+
+    public String getWithColumnLengthAnnotation() {
+        return withColumnLengthAnnotation;
     }
 }


### PR DESCRIPTION
I quickly (and dirtily) added support for the `@Column`-annotation (only the `length`-property of course).

@akutschera, would you mind having a look and maybe give me your opinion? I'm not quite sure if it is a good idea to introduce yet another dependency (`jakarta.persistence`) or would it be better to have both annotations on the entity like so:
```java
@Column(length = 5)
@Size(max = 5)
private String myLimitedString;
```
Further reading: [Baeldung](https://www.baeldung.com/jpa-size-length-column-differences)
What do you think?