### PR TITLE
Catch reflection exceptions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,7 @@
         <maven-gpg-plugin.version>1.5</maven-gpg-plugin.version>
         <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
         <junit-jupiter-engine.version>5.5.1</junit-jupiter-engine.version>
+        <mockito.version>4.5.1</mockito.version>
     </properties>
 
     <dependencies>
@@ -70,7 +71,13 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>3.0.0</version>
+            <version>${mockito.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/com/github/nylle/javafixture/Reflector.java
+++ b/src/main/java/com/github/nylle/javafixture/Reflector.java
@@ -1,6 +1,7 @@
 package com.github.nylle.javafixture;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.InaccessibleObjectException;
 import java.lang.reflect.Modifier;
 import java.util.Optional;
 import java.util.stream.Stream;
@@ -63,7 +64,7 @@ public class Reflector<T> {
             field.set(instance, value);
         } catch (SecurityException e) {
             throw new SpecimenException(format("Unable to access field %s on object of type %s", field.getName(), instance.getClass().getName()), e);
-        } catch (IllegalAccessException e) {
+        } catch (IllegalAccessException | InaccessibleObjectException e) {
             throw new SpecimenException(format("Unable to set field %s on object of type %s", field.getName(), instance.getClass().getName()), e);
         }
     }

--- a/src/main/java/com/github/nylle/javafixture/specimen/GenericSpecimen.java
+++ b/src/main/java/com/github/nylle/javafixture/specimen/GenericSpecimen.java
@@ -5,11 +5,11 @@ import com.github.nylle.javafixture.CustomizationContext;
 import com.github.nylle.javafixture.ISpecimen;
 import com.github.nylle.javafixture.InstanceFactory;
 import com.github.nylle.javafixture.Reflector;
+import com.github.nylle.javafixture.SpecimenException;
 import com.github.nylle.javafixture.SpecimenFactory;
 import com.github.nylle.javafixture.SpecimenType;
 
 import java.lang.annotation.Annotation;
-import java.lang.reflect.InaccessibleObjectException;
 import java.util.Map;
 import java.util.stream.IntStream;
 
@@ -97,7 +97,7 @@ public class GenericSpecimen<T> implements ISpecimen<T> {
                                     specimens.getOrDefault(
                                             field.getGenericType().getTypeName(),
                                             specimenFactory.build(SpecimenType.fromClass(field.getType()))).create(new Annotation[0]))));
-        } catch (InaccessibleObjectException ex ) {
+        } catch (SpecimenException ex ) {
             return context.overwrite(type, instanceFactory.construct(type));
         }
         return result;

--- a/src/main/java/com/github/nylle/javafixture/specimen/ObjectSpecimen.java
+++ b/src/main/java/com/github/nylle/javafixture/specimen/ObjectSpecimen.java
@@ -5,11 +5,11 @@ import com.github.nylle.javafixture.CustomizationContext;
 import com.github.nylle.javafixture.ISpecimen;
 import com.github.nylle.javafixture.InstanceFactory;
 import com.github.nylle.javafixture.Reflector;
+import com.github.nylle.javafixture.SpecimenException;
 import com.github.nylle.javafixture.SpecimenFactory;
 import com.github.nylle.javafixture.SpecimenType;
 
 import java.lang.annotation.Annotation;
-import java.lang.reflect.InaccessibleObjectException;
 import java.util.Map;
 
 import static com.github.nylle.javafixture.CustomizationContext.noContext;
@@ -76,7 +76,7 @@ public class ObjectSpecimen<T> implements ISpecimen<T> {
                                     Map.<String, ISpecimen<?>>of().getOrDefault(
                                             field.getGenericType().getTypeName(),
                                             specimenFactory.build(SpecimenType.fromClass(field.getGenericType()))).create(field.getAnnotations()))));
-        } catch (InaccessibleObjectException ex ) {
+        } catch (SpecimenException ex ) {
             return context.overwrite(type, instanceFactory.construct(type));
         }
         return result;

--- a/src/test/java/com/github/nylle/javafixture/InstanceFactoryTest.java
+++ b/src/test/java/com/github/nylle/javafixture/InstanceFactoryTest.java
@@ -53,8 +53,6 @@ class InstanceFactoryTest {
             assertThat(result).isInstanceOf(TestObjectWithGenericConstructor.class);
             assertThat(result.getValue()).isInstanceOf(String.class);
             assertThat(result.getInteger()).isInstanceOf(Optional.class);
-            assertThat(result.getInteger()).isPresent();
-            assertThat(result.getInteger().get()).isInstanceOf(Integer.class);
         }
 
         @Test

--- a/src/test/java/com/github/nylle/javafixture/ReflectorTest.java
+++ b/src/test/java/com/github/nylle/javafixture/ReflectorTest.java
@@ -4,12 +4,17 @@ import com.github.nylle.javafixture.testobjects.inheritance.GenericChild;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
+import java.lang.reflect.Field;
+import java.lang.reflect.InaccessibleObjectException;
 import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
 
 class ReflectorTest {
 
@@ -79,4 +84,40 @@ class ReflectorTest {
                     .withNoCause();
         }
     }
+
+    @Nested
+    @DisplayName("when setting a field via reflection")
+    class SetField {
+        @DisplayName("an IllegalAccessException is turned to a SpecimenException")
+        @Test
+        void catchIllegalAccessException() throws Exception {
+            var mockedField = Mockito.mock(Field.class);
+            var sut = new Reflector<>("");
+            doThrow(new IllegalAccessException("expected")).when(mockedField).set(any(), any());
+
+            assertThatExceptionOfType(SpecimenException.class)
+                    .isThrownBy(() -> sut.setField(mockedField, ""));
+        }
+
+        @DisplayName("an IllegalAccessException is turned to a SpecimenException")
+        @Test
+        void catchSecurityException() {
+            var mockedField = Mockito.mock(Field.class);
+            var sut = new Reflector<>("");
+            doThrow(new SecurityException("expected")).when(mockedField).setAccessible(true);
+            assertThatExceptionOfType(SpecimenException.class)
+                    .isThrownBy(() -> sut.setField(mockedField, ""));
+        }
+
+        @DisplayName("an InaccessibleObjectException is turned to a SpecimenException")
+        @Test
+        void catchInaccessibleObjectException() {
+            var mockedField = Mockito.mock(Field.class);
+            var sut = new Reflector<>("");
+            doThrow(new InaccessibleObjectException("expected")).when(mockedField).setAccessible(true);
+            assertThatExceptionOfType(SpecimenException.class)
+                    .isThrownBy(() -> sut.setField(mockedField, ""));
+        }
+    }
+
 }


### PR DESCRIPTION
A little refactoring. I think it's better to catch all Reflection-related exceptions in the Reflector class.
This way it's easier to just catch a SpecimenException and not worry about what else we might see in the *Specimen classes.

As a bonus this will allow us to already create a Java 17 record.