### PR TITLE
fix: use customization in top-level object only

### DIFF
--- a/src/main/java/com/github/nylle/javafixture/specimen/GenericSpecimen.java
+++ b/src/main/java/com/github/nylle/javafixture/specimen/GenericSpecimen.java
@@ -10,6 +10,7 @@ import com.github.nylle.javafixture.SpecimenFactory;
 import com.github.nylle.javafixture.SpecimenType;
 
 import java.lang.annotation.Annotation;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.IntStream;
 
@@ -90,7 +91,7 @@ public class GenericSpecimen<T> implements ISpecimen<T> {
                                     field.getName(),
                                     specimens.getOrDefault(
                                             field.getGenericType().getTypeName(),
-                                            specimenFactory.build(SpecimenType.fromClass(field.getType()))).create(customizationContext, new Annotation[0]))));
+                                            specimenFactory.build(SpecimenType.fromClass(field.getType()))).create(new CustomizationContext(List.of(), Map.of()), new Annotation[0]))));
         } catch (SpecimenException ex ) {
             return context.overwrite(type, instanceFactory.construct(type));
         }

--- a/src/main/java/com/github/nylle/javafixture/specimen/ObjectSpecimen.java
+++ b/src/main/java/com/github/nylle/javafixture/specimen/ObjectSpecimen.java
@@ -10,6 +10,7 @@ import com.github.nylle.javafixture.SpecimenFactory;
 import com.github.nylle.javafixture.SpecimenType;
 
 import java.lang.annotation.Annotation;
+import java.util.List;
 import java.util.Map;
 
 public class ObjectSpecimen<T> implements ISpecimen<T> {
@@ -68,7 +69,7 @@ public class ObjectSpecimen<T> implements ISpecimen<T> {
                                     field.getName(),
                                     Map.<String, ISpecimen<?>>of().getOrDefault(
                                             field.getGenericType().getTypeName(),
-                                            specimenFactory.build(SpecimenType.fromClass(field.getGenericType()))).create(customizationContext, field.getAnnotations()))));
+                                            specimenFactory.build(SpecimenType.fromClass(field.getGenericType()))).create(new CustomizationContext(List.of(), Map.of()), field.getAnnotations()))));
         } catch (SpecimenException ex ) {
             return context.overwrite(type, instanceFactory.construct(type));
         }

--- a/src/test/java/com/github/nylle/javafixture/specimen/GenericSpecimenTest.java
+++ b/src/test/java/com/github/nylle/javafixture/specimen/GenericSpecimenTest.java
@@ -6,6 +6,7 @@ import com.github.nylle.javafixture.CustomizationContext;
 import com.github.nylle.javafixture.SpecimenException;
 import com.github.nylle.javafixture.SpecimenFactory;
 import com.github.nylle.javafixture.SpecimenType;
+import com.github.nylle.javafixture.testobjects.TestObject;
 import com.github.nylle.javafixture.testobjects.TestObjectGeneric;
 import com.github.nylle.javafixture.testobjects.inheritance.GenericChild;
 import org.junit.jupiter.api.BeforeEach;
@@ -131,6 +132,21 @@ class GenericSpecimenTest {
                 .withNoCause();
     }
 
+    @Test
+    void customFieldIsOnlyUsedInTopLevelObject() {
+        var sut = new GenericSpecimen<>(new SpecimenType<WithTestObject<Integer>>() {}, context, specimenFactory);
+
+        var customizationContext = new CustomizationContext(List.of(), Map.of("topLevelValue", 42));
+
+        var actual = sut.create(customizationContext, new Annotation[0]);
+
+        assertThat(actual.getTopLevelValue()).isEqualTo(42);
+        assertThat( actual.getTestObject() ).isNotNull();
+        assertThat( actual.getTestObject().getValue() ).isNotNull();
+        assertThat( actual.getTestObject().getStrings() ).isNotEmpty();
+        assertThat( actual.getTestObject().getIntegers() ).isNotEmpty();
+    }
+
     @Nested
     @DisplayName("when specimen has superclass")
     class WhenInheritance {
@@ -198,6 +214,19 @@ class GenericSpecimenTest {
 
             assertThatExceptionOfType(SpecimenException.class)
                     .isThrownBy(() -> sut.create(new CustomizationContext(omitting, Map.of()), new Annotation[0]));
+        }
+    }
+
+    public static class WithTestObject<T> {
+        private T topLevelValue;
+        private TestObject testObject;
+
+        public T getTopLevelValue() {
+            return topLevelValue;
+        }
+
+        public TestObject getTestObject() {
+            return testObject;
         }
     }
 }

--- a/src/test/java/com/github/nylle/javafixture/specimen/ObjectSpecimenTest.java
+++ b/src/test/java/com/github/nylle/javafixture/specimen/ObjectSpecimenTest.java
@@ -138,6 +138,18 @@ class ObjectSpecimenTest {
                 .withNoCause();
     }
 
+    @Test
+    void customFieldIsOnlyUsedInTopLevelObject() {
+        var sut = new ObjectSpecimen<WithTestObject>(SpecimenType.fromClass(WithTestObject.class), context, specimenFactory);
+        var customizationContext = new CustomizationContext(List.of(), Map.of("topLevelValue", 42));
+        var actual = sut.create(customizationContext, new Annotation[0]);
+        assertThat(actual.getTopLevelValue()).isEqualTo(42);
+        assertThat( actual.getTestObject() ).isNotNull();
+        assertThat( actual.getTestObject().getValue() ).isNotNull();
+        assertThat( actual.getTestObject().getStrings() ).isNotEmpty();
+        assertThat( actual.getTestObject().getIntegers() ).isNotEmpty();
+    }
+
     @Nested
     @DisplayName("when specimen has superclass")
     class WhenInheritance {
@@ -205,6 +217,19 @@ class ObjectSpecimenTest {
 
             assertThatExceptionOfType(SpecimenException.class)
                     .isThrownBy(() -> sut.create(new CustomizationContext(omitting, Map.of()), new Annotation[0]));
+        }
+    }
+
+    public static class WithTestObject {
+        private int topLevelValue;
+        private TestObject testObject;
+
+        public int getTopLevelValue() {
+            return topLevelValue;
+        }
+
+        public TestObject getTestObject() {
+            return testObject;
         }
     }
 }


### PR DESCRIPTION
Refs: JF-75

Anything that is customized in 
```
fixture().build(MyClass.class).with("field", "value")
```
will only be applied to MyClass. It is not (yet) possible to customize fields in fields of MyClass. For that you would have to create a fixture of the field object and set it in MyClass.