### PR TITLE
feat: add BigInteger to SpecialSpecimen

### DIFF
--- a/src/main/java/com/github/nylle/javafixture/SpecimenType.java
+++ b/src/main/java/com/github/nylle/javafixture/SpecimenType.java
@@ -162,6 +162,9 @@ public class SpecimenType<T> extends TypeCapture<T> {
     }
 
     public boolean isSpecialType() {
+        if (asClass().equals(java.math.BigInteger.class)) {
+            return true;
+        }
         if (asClass().equals(java.io.File.class)) {
             return true;
         }

--- a/src/main/java/com/github/nylle/javafixture/specimen/SpecialSpecimen.java
+++ b/src/main/java/com/github/nylle/javafixture/specimen/SpecialSpecimen.java
@@ -7,11 +7,14 @@ import com.github.nylle.javafixture.SpecimenType;
 
 import java.io.File;
 import java.lang.annotation.Annotation;
+import java.math.BigInteger;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Random;
 import java.util.UUID;
 
 public class SpecialSpecimen<T> implements ISpecimen<T> {
+    private static final int MAXIMUM_BITLENGTH_FOR_RANDOM_BIGINT = 1024;
     private final SpecimenType<T> type;
     private final Context context;
 
@@ -38,10 +41,24 @@ public class SpecialSpecimen<T> implements ISpecimen<T> {
         if (type.asClass().equals(File.class)) {
             return (T) new File(UUID.randomUUID().toString());
         }
+        if (type.asClass().equals(BigInteger.class)) {
+            return (T) createBigInteger();
+        }
         try {
             return (T) new URI("https://localhost/" + UUID.randomUUID());
         } catch (URISyntaxException e) {
             return null;
         }
+    }
+
+    private BigInteger createBigInteger() {
+        var rnd = new Random();
+        var result = new BigInteger(rnd.nextInt(MAXIMUM_BITLENGTH_FOR_RANDOM_BIGINT), new Random());
+        if (!context.getConfiguration().usePositiveNumbersOnly()) {
+            if (rnd.nextBoolean()) { // negate randomly
+                return result.negate();
+            }
+        }
+        return result;
     }
 }

--- a/src/test/java/com/github/nylle/javafixture/SpecimenTypeTest.java
+++ b/src/test/java/com/github/nylle/javafixture/SpecimenTypeTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.Test;
 import java.io.File;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.math.BigInteger;
 import java.net.URI;
 import java.time.Duration;
 import java.time.Instant;
@@ -258,14 +259,16 @@ class SpecimenTypeTest {
     @Test
     void isSpecialType() {
         assertThat(new SpecimenType<String>() {}.isSpecialType()).isFalse(); // false
-        assertThat(new SpecimenType<URI>() {}.isSpecialType()).isTrue();
         assertThat(new SpecimenType<File>() {}.isSpecialType()).isTrue();
+        assertThat(new SpecimenType<URI>() {}.isSpecialType()).isTrue();
+        assertThat(new SpecimenType<BigInteger>() {}.isSpecialType()).isTrue();
     }
 
     @TestWithCases
     @TestCase(class1 = String.class, bool2 = false)
     @TestCase(class1 = File.class, bool2 = true)
     @TestCase(class1 = URI.class, bool2 = true)
+    @TestCase(class1 = BigInteger.class, bool2 = true)
     void isSpecialTypeFromClass(Class<?> value, boolean expected) {
         assertThat(SpecimenType.fromClass(value).isSpecialType()).isEqualTo(expected);
     }

--- a/src/test/java/com/github/nylle/javafixture/specimen/SpecialSpecimenTest.java
+++ b/src/test/java/com/github/nylle/javafixture/specimen/SpecialSpecimenTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.lang.annotation.Annotation;
+import java.math.BigInteger;
 import java.net.URI;
 import java.util.Map;
 
@@ -54,12 +55,13 @@ public class SpecialSpecimenTest {
         }
 
     }
+
     @Test
     @DisplayName("creating two files creates two different files")
     void createFile() {
         var sut = new SpecialSpecimen<>(SpecimenType.fromClass(File.class), context);
-        var first = (File)sut.create(noContext(), new Annotation[0]);
-        var second = (File)sut.create(noContext(), new Annotation[0]);
+        var first = (File) sut.create(noContext(), new Annotation[0]);
+        var second = (File) sut.create(noContext(), new Annotation[0]);
 
         assertThat(first.getAbsolutePath()).isNotEqualTo(second.getAbsolutePath());
     }
@@ -69,10 +71,10 @@ public class SpecialSpecimenTest {
     void createFileWithoutContext() {
         var sut = new SpecialSpecimen<>(SpecimenType.fromClass(File.class), context);
 
-        var actual = (File)sut.create(noContext(), new Annotation[0]);
+        var actual = (File) sut.create(noContext(), new Annotation[0]);
 
-        assertThat( actual ).isNotNull();
-        assertThat( actual.getAbsolutePath() ).isNotEmpty();
+        assertThat(actual).isNotNull();
+        assertThat(actual.getAbsolutePath()).isNotEmpty();
     }
 
 
@@ -83,9 +85,30 @@ public class SpecialSpecimenTest {
         var actual = sut.create(noContext(), new Annotation[0]);
 
         assertThat(actual).isInstanceOf(URI.class);
-        assertThat( ((URI)actual).getScheme() ).isEqualTo("https");
-        assertThat( ((URI)actual).getHost() ).isNotNull();
-        assertThat( ((URI)actual).getPath() ).isNotEmpty();
+        assertThat(((URI) actual).getScheme()).isEqualTo("https");
+        assertThat(((URI) actual).getHost()).isNotNull();
+        assertThat(((URI) actual).getPath()).isNotEmpty();
+    }
+
+    @Test
+    @DisplayName("create BigInteger creates random number with a maximum bit length of 1024")
+    void createBigInteger() {
+
+        var sut = new SpecialSpecimen<>(new SpecimenType<BigInteger>() {}, context);
+        var actual = sut.create(noContext(), new Annotation[0]);
+
+        assertThat(actual).isInstanceOf(BigInteger.class);
+        assertThat(actual.bitLength()).isLessThanOrEqualTo(1024);
+    }
+
+    @Test
+    @DisplayName("create BigInteger creates non-negative random number when context demands it")
+    void createNonNegativeBigInteger() {
+        var context = new Context(Configuration.configure().usePositiveNumbersOnly(true));
+        var sut = new SpecialSpecimen<>(new SpecimenType<BigInteger>() {}, context);
+        var actual = sut.create(noContext(), new Annotation[0]);
+
+        assertThat(actual).isNotNegative();
     }
 
 }


### PR DESCRIPTION
By limiting the number of bits to max. 1024, we save some time.
Creating a BigInteger with Integer.MAX_VALUE bits can easily take
one second or more.

Refs: JF-78