### PR TITLE
Use customized fields only once.

### DIFF
--- a/src/main/java/com/github/nylle/javafixture/InstanceFactory.java
+++ b/src/main/java/com/github/nylle/javafixture/InstanceFactory.java
@@ -122,7 +122,7 @@ public class InstanceFactory {
 
     private Object createParameter(Parameter parameter, CustomizationContext customizationContext) {
         if (customizationContext.getCustomFields().containsKey(parameter.getName())) {
-            return customizationContext.getCustomFields().get(parameter.getName());
+            return customizationContext.getCustomFields().remove(parameter.getName());
         }
         var specimen = specimenFactory.build(SpecimenType.fromClass(parameter.getParameterizedType()));
         return specimen.create(customizationContext, new Annotation[0]);

--- a/src/test/java/com/github/nylle/javafixture/InstanceFactoryTest.java
+++ b/src/test/java/com/github/nylle/javafixture/InstanceFactoryTest.java
@@ -141,6 +141,18 @@ class InstanceFactoryTest {
             assertThat(first.getStrings()).usingRecursiveComparison().isEqualTo(second.getStrings());
             assertThat(first.getValue()).as("primitives are never cached").isNotEqualTo(second.getValue());
         }
+
+        @Test
+        @DisplayName("customized arguments are only used for the top level object (no nested objects)")
+        void constructorArgumentsAreUsedOnce() {
+            var sut = new InstanceFactory(new SpecimenFactory(new Context(Configuration.configure())));
+
+            var customizationContext = new CustomizationContext(true);
+            customizationContext.getCustomFields().put("arg0", 2);
+            TestObjectWithConstructedField result = sut.construct(fromClass(TestObjectWithConstructedField.class), customizationContext);
+
+            assertThat(result.getSetByConstructor()).isEqualTo(2);
+        }
     }
 
     @Nested

--- a/src/test/java/com/github/nylle/javafixture/testobjects/withconstructor/TestObjectWithConstructedField.java
+++ b/src/test/java/com/github/nylle/javafixture/testobjects/withconstructor/TestObjectWithConstructedField.java
@@ -5,10 +5,13 @@ public class TestObjectWithConstructedField {
 
     private String notSetByConstructor;
 
+    private final int setByConstructor;
+
     private final TestObjectWithGenericConstructor testObjectWithGenericConstructor;
 
 
-    public TestObjectWithConstructedField(TestObjectWithGenericConstructor testObjectWithGenericConstructor) {
+    public TestObjectWithConstructedField(int setByConstructor, TestObjectWithGenericConstructor testObjectWithGenericConstructor) {
+        this.setByConstructor = setByConstructor;
         this.testObjectWithGenericConstructor = testObjectWithGenericConstructor;
     }
 
@@ -18,5 +21,9 @@ public class TestObjectWithConstructedField {
 
     public String getNotSetByConstructor() {
         return notSetByConstructor;
+    }
+
+    public int getSetByConstructor() {
+        return setByConstructor;
     }
 }


### PR DESCRIPTION
Only the top-level object's fields can be customized. By removing the field from the customization context, we ensure it is not used again.

Refs: #92