### PR TITLE
Issue 98 - use pre-defined instances when creating fixtures

### DIFF
--- a/src/main/java/com/github/nylle/javafixture/SpecimenFactory.java
+++ b/src/main/java/com/github/nylle/javafixture/SpecimenFactory.java
@@ -32,7 +32,7 @@ public class SpecimenFactory {
         }
 
         if (type.isEnum()) {
-            return new EnumSpecimen<>(type, context);
+            return new EnumSpecimen<>(type );
         }
 
         if (type.isCollection()) {

--- a/src/main/java/com/github/nylle/javafixture/SpecimenFactory.java
+++ b/src/main/java/com/github/nylle/javafixture/SpecimenFactory.java
@@ -8,6 +8,7 @@ import com.github.nylle.javafixture.specimen.GenericSpecimen;
 import com.github.nylle.javafixture.specimen.InterfaceSpecimen;
 import com.github.nylle.javafixture.specimen.MapSpecimen;
 import com.github.nylle.javafixture.specimen.ObjectSpecimen;
+import com.github.nylle.javafixture.specimen.PredefinedSpecimen;
 import com.github.nylle.javafixture.specimen.PrimitiveSpecimen;
 import com.github.nylle.javafixture.specimen.SpecialSpecimen;
 import com.github.nylle.javafixture.specimen.TimeSpecimen;
@@ -21,6 +22,10 @@ public class SpecimenFactory {
     }
 
     public <T> ISpecimen<T> build(final SpecimenType<T> type) {
+
+        if ( context.isCached(type) ) {
+            return new PredefinedSpecimen<>( type, context );
+        }
 
         if (type.isPrimitive() || type.isBoxed() || type.asClass() == String.class) {
             return new PrimitiveSpecimen<>(type, context);

--- a/src/main/java/com/github/nylle/javafixture/specimen/EnumSpecimen.java
+++ b/src/main/java/com/github/nylle/javafixture/specimen/EnumSpecimen.java
@@ -1,6 +1,5 @@
 package com.github.nylle.javafixture.specimen;
 
-import com.github.nylle.javafixture.Context;
 import com.github.nylle.javafixture.CustomizationContext;
 import com.github.nylle.javafixture.ISpecimen;
 import com.github.nylle.javafixture.SpecimenType;
@@ -12,9 +11,8 @@ public class EnumSpecimen<T> implements ISpecimen<T> {
 
     private final SpecimenType<T> type;
     private final Random random;
-    private final Context context;
 
-    public EnumSpecimen(final SpecimenType<T> type, final Context context) {
+    public EnumSpecimen(final SpecimenType<T> type ) {
 
         if (type == null) {
             throw new IllegalArgumentException("type: null");
@@ -24,17 +22,12 @@ public class EnumSpecimen<T> implements ISpecimen<T> {
             throw new IllegalArgumentException("type: " + type.getName());
         }
 
-        if (context == null) {
-            throw new IllegalArgumentException("context: null");
-        }
-
         this.type = type;
         this.random = new Random();
-        this.context = context;
     }
 
     @Override
     public T create(CustomizationContext customizationContext, Annotation[] annotations) {
-        return context.preDefined(type, type.getEnumConstants()[random.nextInt(type.getEnumConstants().length)]);
+        return type.getEnumConstants()[random.nextInt(type.getEnumConstants().length)];
     }
 }

--- a/src/main/java/com/github/nylle/javafixture/specimen/PredefinedSpecimen.java
+++ b/src/main/java/com/github/nylle/javafixture/specimen/PredefinedSpecimen.java
@@ -1,0 +1,32 @@
+package com.github.nylle.javafixture.specimen;
+
+import com.github.nylle.javafixture.Context;
+import com.github.nylle.javafixture.CustomizationContext;
+import com.github.nylle.javafixture.ISpecimen;
+import com.github.nylle.javafixture.SpecimenType;
+
+import java.lang.annotation.Annotation;
+
+public class PredefinedSpecimen<T> implements ISpecimen<T> {
+
+    private final Context context;
+    private final SpecimenType<T> type;
+
+    public PredefinedSpecimen( SpecimenType<T> type, Context context ) {
+        if (type == null) {
+            throw new IllegalArgumentException("type: null");
+        }
+
+        if (context == null) {
+            throw new IllegalArgumentException("context: null");
+        }
+
+        this.context = context;
+        this.type = type;
+    }
+
+    @Override
+    public T create( CustomizationContext customizationContext, Annotation[] annotations ) {
+        return context.cached( type );
+    }
+}

--- a/src/main/java/com/github/nylle/javafixture/specimen/PrimitiveSpecimen.java
+++ b/src/main/java/com/github/nylle/javafixture/specimen/PrimitiveSpecimen.java
@@ -16,7 +16,6 @@ public class PrimitiveSpecimen<T> implements ISpecimen<T> {
     private final SpecimenType<T> type;
     private final PseudoRandom pseudoRandom;
     private final Configuration configuration;
-    private final Context context;
 
     public PrimitiveSpecimen(final SpecimenType<T> type, final Context context) {
 
@@ -35,46 +34,45 @@ public class PrimitiveSpecimen<T> implements ISpecimen<T> {
         this.type = type;
         this.pseudoRandom = new PseudoRandom();
         this.configuration = context.getConfiguration();
-        this.context = context;
     }
 
     @Override
     public T create(final CustomizationContext customizationContext, Annotation[] annotations) {
         if (type.asClass().equals(String.class)) {
             StringConstraints constraints = getStringConstraints(annotations);
-            return context.preDefined(type, (T) pseudoRandom.nextString(constraints));
+            return (T) pseudoRandom.nextString(constraints);
         }
 
         if (type.asClass().equals(Boolean.class) || type.asClass().equals(boolean.class)) {
-            return context.preDefined(type, (T) pseudoRandom.nextBool());
+            return (T) pseudoRandom.nextBool();
         }
 
         if (type.asClass().equals(Character.class) || type.asClass().equals(char.class)) {
-            return context.preDefined(type, (T) pseudoRandom.nextChar());
+            return (T) pseudoRandom.nextChar();
         }
 
         if (type.asClass().equals(Byte.class) || type.asClass().equals(byte.class)) {
-            return context.preDefined(type, (T) pseudoRandom.nextByte());
+            return (T) pseudoRandom.nextByte();
         }
 
         if (type.asClass().equals(Short.class) || type.asClass().equals(short.class)) {
-            return context.preDefined(type, (T) pseudoRandom.nextShort(configuration.usePositiveNumbersOnly()));
+            return (T) pseudoRandom.nextShort(configuration.usePositiveNumbersOnly());
         }
 
         if (type.asClass().equals(Integer.class) || type.asClass().equals(int.class)) {
-            return context.preDefined(type, (T) pseudoRandom.nextInt(configuration.usePositiveNumbersOnly()));
+            return (T) pseudoRandom.nextInt(configuration.usePositiveNumbersOnly());
         }
 
         if (type.asClass().equals(Long.class) || type.asClass().equals(long.class)) {
-            return context.preDefined(type, (T) pseudoRandom.nextLong(configuration.usePositiveNumbersOnly()));
+            return (T) pseudoRandom.nextLong(configuration.usePositiveNumbersOnly());
         }
 
         if (type.asClass().equals(Float.class) || type.asClass().equals(float.class)) {
-            return context.preDefined(type, (T) pseudoRandom.nextFloat(configuration.usePositiveNumbersOnly()));
+            return (T) pseudoRandom.nextFloat(configuration.usePositiveNumbersOnly());
         }
 
         if (type.asClass().equals(Double.class) || type.asClass().equals(double.class)) {
-            return context.preDefined(type, (T) pseudoRandom.nextDouble(configuration.usePositiveNumbersOnly()));
+            return (T) pseudoRandom.nextDouble(configuration.usePositiveNumbersOnly());
         }
 
         throw new SpecimenException("Unsupported type: " + type);

--- a/src/main/java/com/github/nylle/javafixture/specimen/TimeSpecimen.java
+++ b/src/main/java/com/github/nylle/javafixture/specimen/TimeSpecimen.java
@@ -49,41 +49,41 @@ public class TimeSpecimen<T> implements ISpecimen<T> {
         if (Temporal.class.isAssignableFrom(type.asClass())) {
             try {
                 Method now = type.asClass().getMethod("now", Clock.class);
-                return context.preDefined(type, (T) now.invoke(null, context.getConfiguration().getClock()));
+                return (T) now.invoke(null, context.getConfiguration().getClock());
             } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
                 throw new SpecimenException("Unsupported type: " + type.asClass());
             }
         }
 
         if (type.asClass().equals(java.util.Date.class)) {
-            return context.preDefined(type, (T) java.sql.Timestamp.valueOf(LocalDateTime.now(context.getConfiguration().getClock())));
+            return (T) java.sql.Timestamp.valueOf(LocalDateTime.now(context.getConfiguration().getClock()));
         }
 
         if (type.asClass().equals(java.sql.Date.class)) {
-            return context.preDefined(type, (T) java.sql.Date.valueOf(LocalDateTime.now(context.getConfiguration().getClock()).toLocalDate()));
+            return (T) java.sql.Date.valueOf(LocalDateTime.now(context.getConfiguration().getClock()).toLocalDate());
         }
 
         if (type.asClass().equals(MonthDay.class)) {
-            return context.preDefined(type, (T) MonthDay.now(context.getConfiguration().getClock()));
+            return (T) MonthDay.now(context.getConfiguration().getClock());
         }
 
         if (type.asClass().equals(JapaneseEra.class)) {
-            return context.preDefined(type, (T) JapaneseEra.values()[random.nextInt(JapaneseEra.values().length)]);
+            return (T) JapaneseEra.values()[random.nextInt(JapaneseEra.values().length)];
         }
 
         if (type.asClass().equals(ZoneOffset.class)) {
-            return context.preDefined(type, (T) ZoneOffset.ofHours(new Random().nextInt(19)));
+            return (T) ZoneOffset.ofHours(new Random().nextInt(19));
         }
         if (type.asClass().equals(Duration.class)) {
-            return context.preDefined(type, (T) Duration.ofDays(random.nextInt()));
+            return (T) Duration.ofDays(random.nextInt());
         }
 
         if (type.asClass().equals(Period.class)) {
-            return context.preDefined(type, (T) Period.ofDays(random.nextInt()));
+            return (T) Period.ofDays(random.nextInt());
         }
 
         if (type.asClass().equals(ZoneId.class)) {
-            return context.preDefined(type, (T) ZoneId.of(ZoneId.getAvailableZoneIds().iterator().next()));
+            return (T) ZoneId.of(ZoneId.getAvailableZoneIds().iterator().next());
         }
 
         throw new SpecimenException("Unsupported type: " + type.asClass());

--- a/src/test/java/com/github/nylle/javafixture/FixtureTest.java
+++ b/src/test/java/com/github/nylle/javafixture/FixtureTest.java
@@ -19,6 +19,7 @@ import com.github.nylle.javafixture.testobjects.example.ContractCategory;
 import com.github.nylle.javafixture.testobjects.example.ContractPosition;
 import com.github.nylle.javafixture.testobjects.withconstructor.TestObjectWithGenericConstructor;
 import com.github.nylle.javafixture.testobjects.withconstructor.TestObjectWithoutDefaultConstructor;
+import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -242,13 +243,18 @@ class FixtureTest {
         @Test
         void objectCanBeCustomizedWithType() {
             var expected = Period.ofDays(42);
+            var expectedFile = new File( "expected-file-name" );
             var result = fixture().build(Contract.class)
                     .with(Period.class, expected)
+                    .with(File.class, expectedFile)
                     .create();
 
             var actual = result.getBaseContractPosition().getRemainingPeriod();
 
-            assertThat(actual).isSameAs(expected);
+            var softly = new SoftAssertions();
+            softly.assertThat(actual).isSameAs(expected);
+            softly.assertThat(result.getBaseContractPosition().getFile()).isEqualTo( expectedFile );
+            softly.assertAll();
         }
 
         @Test

--- a/src/test/java/com/github/nylle/javafixture/SpecimenFactoryTest.java
+++ b/src/test/java/com/github/nylle/javafixture/SpecimenFactoryTest.java
@@ -9,12 +9,15 @@ import com.github.nylle.javafixture.specimen.GenericSpecimen;
 import com.github.nylle.javafixture.specimen.InterfaceSpecimen;
 import com.github.nylle.javafixture.specimen.MapSpecimen;
 import com.github.nylle.javafixture.specimen.ObjectSpecimen;
+import com.github.nylle.javafixture.specimen.PredefinedSpecimen;
 import com.github.nylle.javafixture.specimen.PrimitiveSpecimen;
 import com.github.nylle.javafixture.specimen.SpecialSpecimen;
 import com.github.nylle.javafixture.specimen.TimeSpecimen;
 import com.github.nylle.javafixture.testobjects.TestEnum;
 import com.github.nylle.javafixture.testobjects.TestObjectGeneric;
+import com.github.nylle.javafixture.testobjects.TestPrimitive;
 import com.github.nylle.javafixture.testobjects.example.IContract;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
@@ -66,7 +69,18 @@ class SpecimenFactoryTest {
         assertThat(sut.build(new SpecimenType<Map<String, Integer>>(){})).isExactlyInstanceOf(MapSpecimen.class);
         assertThat(sut.build(new SpecimenType<Class<String>>(){})).isExactlyInstanceOf(GenericSpecimen.class);
         assertThat(sut.build(new SpecimenType<TestObjectGeneric<String, List<Integer>>>(){})).isExactlyInstanceOf(GenericSpecimen.class);
+    }
 
+    @Test
+    @DisplayName( "when cache contains a predefined value, return this" )
+    void buildReturnsCacnedValue() {
+        var context = new Context( new Configuration() );
+        var cachedValue = new TestPrimitive();
+        var type = SpecimenType.fromClass( TestPrimitive.class );
+        context.overwrite( type, cachedValue );
+        var sut = new SpecimenFactory( context );
+
+        assertThat( sut.build( type ) ).isExactlyInstanceOf( PredefinedSpecimen.class );
     }
 
 

--- a/src/test/java/com/github/nylle/javafixture/specimen/EnumSpecimenTest.java
+++ b/src/test/java/com/github/nylle/javafixture/specimen/EnumSpecimenTest.java
@@ -1,46 +1,41 @@
 package com.github.nylle.javafixture.specimen;
 
-import com.github.nylle.javafixture.Configuration;
-import com.github.nylle.javafixture.Context;
 import com.github.nylle.javafixture.SpecimenType;
 import com.github.nylle.javafixture.testobjects.TestEnum;
 import org.junit.jupiter.api.Test;
 
 import java.lang.annotation.Annotation;
-import java.util.Map;
 
-import static com.github.nylle.javafixture.Configuration.configure;
 import static com.github.nylle.javafixture.CustomizationContext.noContext;
-import static com.github.nylle.javafixture.Fixture.fixture;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class EnumSpecimenTest {
 
     @Test
     void typeIsRequired() {
-        assertThatThrownBy(() -> new EnumSpecimen<>(null, new Context(configure())))
+        assertThatThrownBy(() -> new EnumSpecimen<>(null ))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("type: null");
     }
 
     @Test
     void onlyEnumTypes() {
-        assertThatThrownBy(() -> new EnumSpecimen<>(SpecimenType.fromClass(Object.class), new Context(configure())))
+        assertThatThrownBy(() -> new EnumSpecimen<>(SpecimenType.fromClass(Object.class) ))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("type: " + Object.class.getName());
     }
 
     @Test
-    void contextIsRequired() {
-        assertThatThrownBy(() -> new EnumSpecimen<>(SpecimenType.fromClass(TestEnum.class), null))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("context: null");
+    void contextIsNotRequired() {
+        assertThatCode(() -> new EnumSpecimen<>(SpecimenType.fromClass(TestEnum.class) ))
+                .doesNotThrowAnyException();
     }
 
     @Test
     void createEnum() {
-        var sut = new EnumSpecimen<>(SpecimenType.fromClass(TestEnum.class), new Context(configure()));
+        var sut = new EnumSpecimen<>(SpecimenType.fromClass(TestEnum.class) );
 
         var actual = sut.create(noContext(), new Annotation[0]);
 
@@ -48,16 +43,4 @@ class EnumSpecimenTest {
         assertThat(actual.toString()).isIn("VALUE1", "VALUE2", "VALUE3");
     }
 
-    @Test
-    void canBePredefined() {
-        var expected = fixture().create(TestEnum.class);
-
-        var context = new Context(Configuration.configure(), Map.of(SpecimenType.fromClass(TestEnum.class), expected));
-
-        var sut = new EnumSpecimen<>(SpecimenType.fromClass(TestEnum.class), context);
-
-        var actual = sut.create(noContext(), new Annotation[0]);
-
-        assertThat(actual).isSameAs(expected);
-    }
 }

--- a/src/test/java/com/github/nylle/javafixture/specimen/PredefinedSpecimenTest.java
+++ b/src/test/java/com/github/nylle/javafixture/specimen/PredefinedSpecimenTest.java
@@ -1,0 +1,47 @@
+package com.github.nylle.javafixture.specimen;
+
+import com.github.nylle.javafixture.Context;
+import com.github.nylle.javafixture.SpecimenType;
+import com.github.nylle.javafixture.testobjects.TestEnum;
+import com.github.nylle.javafixture.testobjects.TestObject;
+import org.junit.jupiter.api.Test;
+
+import static com.github.nylle.javafixture.Configuration.configure;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class PredefinedSpecimenTest {
+    @Test
+    void typeIsRequired() {
+        assertThatThrownBy(() -> new PredefinedSpecimen<>(null, new Context( configure())))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("type: null");
+    }
+
+    @Test
+    void contextIsRequired() {
+        assertThatThrownBy(() -> new PredefinedSpecimen<>( SpecimenType.fromClass( TestEnum.class), null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("context: null");
+    }
+
+    @Test
+    void createReturnsCachedValue() {
+        var type = SpecimenType.fromClass( TestObject.class );
+        var testObject = new TestObject( null, null, null );
+        var context = new Context( configure() );
+        context.overwrite( type,  testObject);
+        var sut = new PredefinedSpecimen<>( type, context );
+
+        assertThat( sut.create( null, null ) ).isEqualTo( testObject );
+    }
+
+    @Test
+    void createReturnsNullIfNoCachedValueIsFound() {
+        var type = SpecimenType.fromClass( TestObject.class );
+        var context = new Context( configure() );
+        var sut = new PredefinedSpecimen<>( type, context );
+
+        assertThat( sut.create( null, null ) ).isNull();
+    }
+}

--- a/src/test/java/com/github/nylle/javafixture/specimen/PrimitiveSpecimenTest.java
+++ b/src/test/java/com/github/nylle/javafixture/specimen/PrimitiveSpecimenTest.java
@@ -1,6 +1,5 @@
 package com.github.nylle.javafixture.specimen;
 
-import com.github.nylle.javafixture.Configuration;
 import com.github.nylle.javafixture.Context;
 import com.github.nylle.javafixture.SpecimenType;
 import com.github.nylle.javafixture.annotations.testcases.TestCase;
@@ -8,11 +7,9 @@ import com.github.nylle.javafixture.annotations.testcases.TestWithCases;
 import org.junit.jupiter.api.Test;
 
 import java.lang.annotation.Annotation;
-import java.util.Map;
 
 import static com.github.nylle.javafixture.Configuration.configure;
 import static com.github.nylle.javafixture.CustomizationContext.noContext;
-import static com.github.nylle.javafixture.Fixture.fixture;
 import static com.github.nylle.javafixture.SpecimenType.fromClass;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -128,28 +125,6 @@ class PrimitiveSpecimenTest {
 
         assertThat(actual).isInstanceOf(Double.class);
         assertThat(actual).isBetween(min, max);
-    }
-
-    @TestWithCases
-    @TestCase(class1 = String.class)
-    @TestCase(class1 = Boolean.class)
-    @TestCase(class1 = Character.class)
-    @TestCase(class1 = Byte.class)
-    @TestCase(class1 = Short.class)
-    @TestCase(class1 = Integer.class)
-    @TestCase(class1 = Long.class)
-    @TestCase(class1 = Float.class)
-    @TestCase(class1 = Double.class)
-    void canBePredefined(Class type) {
-        var expected = fixture().create(type);
-
-        var context = new Context(Configuration.configure(), Map.of(SpecimenType.fromClass(type), expected));
-
-        var sut = new PrimitiveSpecimen<>(SpecimenType.fromClass(type), context);
-
-        var actual = sut.create(noContext(), new Annotation[0]);
-
-        assertThat(actual).isSameAs(expected);
     }
 
 }

--- a/src/test/java/com/github/nylle/javafixture/specimen/TimeSpecimenTest.java
+++ b/src/test/java/com/github/nylle/javafixture/specimen/TimeSpecimenTest.java
@@ -36,7 +36,6 @@ import java.time.temporal.TemporalAmount;
 import java.util.Map;
 
 import static com.github.nylle.javafixture.CustomizationContext.noContext;
-import static com.github.nylle.javafixture.Fixture.fixture;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.when;
@@ -130,37 +129,4 @@ class TimeSpecimenTest {
         assertThat(actual).isEqualTo(Instant.MIN);
     }
 
-    @TestWithCases
-    @TestCase(class1 = Instant.class)
-    @TestCase(class1 = HijrahDate.class)
-    @TestCase(class1 = JapaneseDate.class)
-    @TestCase(class1 = LocalDate.class)
-    @TestCase(class1 = LocalDateTime.class)
-    @TestCase(class1 = LocalTime.class)
-    @TestCase(class1 = MinguoDate.class)
-    @TestCase(class1 = OffsetDateTime.class)
-    @TestCase(class1 = OffsetTime.class)
-    @TestCase(class1 = ThaiBuddhistDate.class)
-    @TestCase(class1 = Year.class)
-    @TestCase(class1 = YearMonth.class)
-    @TestCase(class1 = ZonedDateTime.class)
-    @TestCase(class1 = java.sql.Date.class)
-    @TestCase(class1 = java.util.Date.class)
-    @TestCase(class1 = Duration.class)
-    @TestCase(class1 = JapaneseEra.class)
-    @TestCase(class1 = MonthDay.class)
-    @TestCase(class1 = Period.class)
-    @TestCase(class1 = ZoneId.class)
-    @TestCase(class1 = ZoneOffset.class)
-    void canBePredefined(Class type) {
-        var expected = fixture().create(type);
-
-        var context = new Context(Configuration.configure(), Map.of(SpecimenType.fromClass(type), expected));
-
-        var sut = new TimeSpecimen<>(SpecimenType.fromClass(type), context);
-
-        var actual = sut.create(noContext(), new Annotation[0]);
-
-        assertThat(actual).isSameAs(expected);
-    }
 }


### PR DESCRIPTION
During the fix I noticed that we can simplify the caching by checking for chached values in the SpecimenFactory instead of each Specimen.

A bonus effect is that we don't construct e.g. PrimitiveSpecimen anymore that we won't use because the type was pre-defined.