### PR TITLE
make code compilable with OpenJDK21

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,8 @@
         <maven-gpg-plugin.version>1.5</maven-gpg-plugin.version>
         <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
         <junit-jupiter-engine.version>5.5.1</junit-jupiter-engine.version>
-        <mockito.version>4.5.1</mockito.version>
+        <mockito.version>5.11.0</mockito.version>
+        <assertj-core.version>3.25.1</assertj-core.version>
     </properties>
 
     <dependencies>
@@ -80,18 +81,12 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>3.23.1</version>
+            <version>${assertj-core.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>${mockito.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-inline</artifactId>
             <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
AssertJ 3.25.1 has a byte-buddy version that can handle Java 21 class files.
The update to Mockito 5.11 allows us to get rid of the mockito-inline dependency.

This only affects testing of JavaFixture.

The resulting code is still compatible with Java 11.
It's just convenience when you try to run the JavaFixture tests locally and your default Java version is > 19.