### PR TITLE
build: upgrade dependencies for Java 24 #117

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,8 +24,8 @@
         <maven-gpg-plugin.version>1.5</maven-gpg-plugin.version>
         <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
         <junit-jupiter-engine.version>5.5.1</junit-jupiter-engine.version>
-        <mockito.version>5.14.2</mockito.version>
-        <assertj-core.version>3.26.3</assertj-core.version>
+        <mockito.version>5.17.0</mockito.version>
+        <assertj-core.version>3.27.3</assertj-core.version>
         <argLine/>
     </properties>
 
@@ -132,7 +132,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.5.1</version>
+                <version>3.5.3</version>
                 <configuration>
                     <argLine>@{argLine} -javaagent:${org.mockito:mockito-core:jar}</argLine>
                 </configuration>


### PR DESCRIPTION
Just a few dependency upgrades.
I checked and could run all tests with JDKs 11, 17, 21, 22, 23 and 24.
This will only affect working on the code with a local JDK version of 24.
The resulting byte code version is still 11.