### PR TITLE
fix: remove constructed objects from cache #125

### DIFF
--- a/src/main/java/com/github/nylle/javafixture/specimen/ObjectSpecimen.java
+++ b/src/main/java/com/github/nylle/javafixture/specimen/ObjectSpecimen.java
@@ -68,7 +68,7 @@ public class ObjectSpecimen<T> implements ISpecimen<T> {
                                             .build(SpecimenType.fromClass(field.getGenericType()))
                                             .create(customizationContext.newForField(field.getName()), reflector.getFieldAnnotations(field)))));
         } catch (SpecimenException ex) {
-            return context.overwrite(type, instanceFactory.construct(type, customizationContext));
+            context.overwrite(type, instanceFactory.construct(type, customizationContext));
         }
         return context.remove(type);
     }

--- a/src/test/java/com/github/nylle/javafixture/specimen/CollectionSpecimenTest.java
+++ b/src/test/java/com/github/nylle/javafixture/specimen/CollectionSpecimenTest.java
@@ -142,6 +142,17 @@ class CollectionSpecimenTest {
     }
 
     @Test
+    void createSetWhenObjectIsCreatedWithConstructor() {
+        var sut = new CollectionSpecimen<>(new SpecimenType<Set<Throwable>>() {}, context, specimenFactory);
+
+        var actual = sut.create(noContext(), new Annotation[0]);
+
+        assertThat(actual).isInstanceOf(HashSet.class);
+        assertThat(actual.stream().allMatch(x -> x.getClass().equals(Throwable.class))).isTrue();
+        assertThat(actual.size()).isEqualTo(2);
+    }
+
+    @Test
     void createLinkedBlockingDequeFromBlockingDequeInterface() {
         var sut = new CollectionSpecimen<>(new SpecimenType<BlockingDeque<String>>() {}, context, specimenFactory);
 


### PR DESCRIPTION
When we cannot fill an object via reflection (e.g. records), then we need to remove the object from the cache after we created it. We need to do this in order to actually fill sets with more than one member